### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix command injection in run_script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ pnpm-debug.log*
 .DS_Store
 # Build output
 dist/
+.jules/

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,4 +1,0 @@
-## 2024-05-18 - Command Injection in run_script tool
-**Vulnerability:** The `run_script` tool in `src/presentation/mcpServer.ts` accepted unvalidated `script` and `args` parameters and concatenated them into a string passed to `child_process.execSync` using bash. This allowed an attacker to inject arbitrary shell commands by providing characters like `;`, `&`, or `|`.
-**Learning:** Even internal or local-first MCP server tools must treat all incoming parameters as untrusted input. Concatenating strings to form shell commands is highly prone to injection vulnerabilities.
-**Prevention:** Always validate and sanitize inputs that will be used in shell commands. Use a regex to block dangerous characters (e.g., `/[&|;<>$`\n\r]/`), or better yet, use execution methods that accept an array of arguments instead of a single string (like `child_process.spawn`) to completely bypass shell parsing.

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-18 - Command Injection in run_script tool
+**Vulnerability:** The `run_script` tool in `src/presentation/mcpServer.ts` accepted unvalidated `script` and `args` parameters and concatenated them into a string passed to `child_process.execSync` using bash. This allowed an attacker to inject arbitrary shell commands by providing characters like `;`, `&`, or `|`.
+**Learning:** Even internal or local-first MCP server tools must treat all incoming parameters as untrusted input. Concatenating strings to form shell commands is highly prone to injection vulnerabilities.
+**Prevention:** Always validate and sanitize inputs that will be used in shell commands. Use a regex to block dangerous characters (e.g., `/[&|;<>$`\n\r]/`), or better yet, use execution methods that accept an array of arguments instead of a single string (like `child_process.spawn`) to completely bypass shell parsing.

--- a/src/presentation/mcpServer.ts
+++ b/src/presentation/mcpServer.ts
@@ -1627,6 +1627,14 @@ export function registerTools(server: McpServer) {
         } catch { /* skip */ }
       }
 
+      // Security validation to prevent command injection
+      if (/[&|;<>$`\n\r]/.test(script)) {
+        return { content: [{ type: "text" as const, text: JSON.stringify({ error: "Invalid script name: Contains forbidden shell characters" }) }] };
+      }
+      if (args && /[&|;<>$`\n\r]/.test(args)) {
+        return { content: [{ type: "text" as const, text: JSON.stringify({ error: "Invalid arguments: Contains forbidden shell characters" }) }] };
+      }
+
       const cmd = `cd ${JSON.stringify(projectDir)} && npm run ${script}${args ? " " + args : ""}`;
       const maxTime = Math.min(timeout || 60, 300);
       const startTime = Date.now();


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Command Injection in `run_script` tool. The tool concatenates unvalidated `script` and `args` inputs directly into a shell string executed via `child_process.execSync`.
🎯 **Impact:** An attacker could execute arbitrary shell commands on the host machine running the MCP server by injecting characters like `;`, `&`, or `|` into the `script` or `args` parameters.
🔧 **Fix:** Added strict regex validation `/[&|;<>$`\n\r]/` to reject any input containing shell metacharacters before constructing the command string.
✅ **Verification:** Verified via local payload execution that malicious payloads are now correctly rejected with an error message instead of being executed. Existing build/lint checks passed.

---
*PR created automatically by Jules for task [6810730617106948470](https://jules.google.com/task/6810730617106948470) started by @giauphan*