### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix Use execFileSync instead of execSync for git commands

### DIFF
--- a/src/presentation/mcpServer.ts
+++ b/src/presentation/mcpServer.ts
@@ -1691,16 +1691,16 @@ export function registerTools(server: McpServer) {
       const cp = require("child_process");
 
       try {
-        result.branch = cp.execSync("git rev-parse --abbrev-ref HEAD", { cwd: projectDir, encoding: "utf-8" }).toString().trim();
-        const st = cp.execSync("git status --porcelain", { cwd: projectDir, encoding: "utf-8" }).toString();
+        result.branch = cp.execFileSync("git", ["rev-parse", "--abbrev-ref", "HEAD"], { cwd: projectDir, encoding: "utf-8" }).toString().trim();
+        const st = cp.execFileSync("git", ["status", "--porcelain"], { cwd: projectDir, encoding: "utf-8" }).toString();
         const mod: string[] = [], add: string[] = [], del: string[] = [];
         for (const line of st.split("\n").map((x: string) => x.trim()).filter(Boolean)) { const s = line.substring(0, 2), f = line.substring(3); if (s.includes("M")) mod.push(f); if (s.includes("A")) add.push(f); if (s.includes("D")) del.push(f); }
         result.uncommitted = { modified: mod.slice(0, 20), added: add.slice(0, 10), deleted: del.slice(0, 10), hasChanges: st.trim().length > 0 };
         try {
-          const [behind, ahead] = cp.execSync("git rev-list --left-right --count HEAD...@{upstream}", { cwd: projectDir, encoding: "utf-8" }).toString().trim().split("\t").map(Number);
+          const [behind, ahead] = cp.execFileSync("git", ["rev-list", "--left-right", "--count", "HEAD...@{upstream}"], { cwd: projectDir, encoding: "utf-8" }).toString().trim().split("\t").map(Number);
           result.ahead = ahead || 0; result.behind = behind || 0;
         } catch { result.ahead = null; result.behind = null; }
-        const logRaw = cp.execSync(`git log -${maxC} --format="COMMIT%n%H%n%an%n%ai%n%s%nFILES:" --name-only`, { cwd: projectDir, encoding: "utf-8", maxBuffer: 1024 * 1024 }).toString();
+        const logRaw = cp.execFileSync("git", ["log", `-${maxC}`, '--format=COMMIT%n%H%n%an%n%ai%n%s%nFILES:', "--name-only"], { cwd: projectDir, encoding: "utf-8", maxBuffer: 1024 * 1024 }).toString();
         result.recentCommits = [];
         for (const block of logRaw.split("COMMIT\n").filter(Boolean)) {
           const ls = block.trim().split("\n"); if (ls.length < 4) continue;


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Used `child_process.execSync` which invokes a shell, opening up the possibility of shell injection when command strings are interpolated.
🎯 Impact: While the current usage was fairly constrained, any dynamically generated strings passed to `execSync` run the risk of unintended shell execution, which could be exploited.
🔧 Fix: Upgraded to `child_process.execFileSync` passing arguments as a secure array directly to the executable, avoiding the shell entirely. Also appropriately cleaned up `--format` quote wrappers that are unneeded without a shell.
✅ Verification: Ran unit tests to verify behavior remains correct and identical, specifically for git commands execution without throwing shell-related syntax errors.

---
*PR created automatically by Jules for task [10227208486503614046](https://jules.google.com/task/10227208486503614046) started by @giauphan*