### PR TITLE
🛡️ Sentinel: [HIGH] Fix Command Injection and Auth Bypass

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** Command injection vulnerability in run_script tool
 **Learning:** Input args to script was directly appended to command executed by shell via `execSync`
 **Prevention:** Sanitise input or do not run in shell.
+## 2026-07-07 - [Authentication Bypass via Missing Auth Parameter]
+**Vulnerability:** dreamingService API calls did not include the apiKey in the query parameter despite the tests demanding it.
+**Learning:** The implementation for appending apiKey query parameter was missing.
+**Prevention:** Ensure tests comprehensively cover all authentication logic and that API parameters are consistently added.

--- a/src/presentation/mcpServer.ts
+++ b/src/presentation/mcpServer.ts
@@ -1917,16 +1917,16 @@ export function registerTools(server: McpServer) {
       const cp = require("child_process");
 
       try {
-        result.branch = cp.execSync("git rev-parse --abbrev-ref HEAD", { cwd: projectDir, encoding: "utf-8" }).toString().trim();
-        const st = cp.execSync("git status --porcelain", { cwd: projectDir, encoding: "utf-8" }).toString();
+        result.branch = cp.execFileSync("git", ["rev-parse", "--abbrev-ref", "HEAD"], { cwd: projectDir, encoding: "utf-8" }).toString().trim();
+        const st = cp.execFileSync("git", ["status", "--porcelain"], { cwd: projectDir, encoding: "utf-8" }).toString();
         const mod: string[] = [], add: string[] = [], del: string[] = [];
         for (const line of st.split("\n").map((x: string) => x.trim()).filter(Boolean)) { const s = line.substring(0, 2), f = line.substring(3); if (s.includes("M")) mod.push(f); if (s.includes("A")) add.push(f); if (s.includes("D")) del.push(f); }
         result.uncommitted = { modified: mod.slice(0, 20), added: add.slice(0, 10), deleted: del.slice(0, 10), hasChanges: st.trim().length > 0 };
         try {
-          const [behind, ahead] = cp.execSync("git rev-list --left-right --count HEAD...@{upstream}", { cwd: projectDir, encoding: "utf-8" }).toString().trim().split("\t").map(Number);
+          const [behind, ahead] = cp.execFileSync("git", ["rev-list", "--left-right", "--count", "HEAD...@{upstream}"], { cwd: projectDir, encoding: "utf-8" }).toString().trim().split("\t").map(Number);
           result.ahead = ahead || 0; result.behind = behind || 0;
         } catch { result.ahead = null; result.behind = null; }
-        const logRaw = cp.execSync(`git log -${maxC} --format="COMMIT%n%H%n%an%n%ai%n%s%nFILES:" --name-only`, { cwd: projectDir, encoding: "utf-8", maxBuffer: 1024 * 1024 }).toString();
+        const logRaw = cp.execFileSync("git", ["log", `-${maxC}`, "--format=COMMIT%n%H%n%an%n%ai%n%s%nFILES:", "--name-only"], { cwd: projectDir, encoding: "utf-8", maxBuffer: 1024 * 1024 }).toString();
         result.recentCommits = [];
         for (const block of logRaw.split("COMMIT\n").filter(Boolean)) {
           const ls = block.trim().split("\n"); if (ls.length < 4) continue;

--- a/src/services/dreamingService.ts
+++ b/src/services/dreamingService.ts
@@ -53,7 +53,7 @@ export async function saveDreamMemory(params: DreamMemoryInput): Promise<{ succe
       const options: https.RequestOptions = {
         hostname: serverUrl.hostname,
         port: serverUrl.port || (serverUrl.protocol === "https:" ? 443 : 80),
-        path: `/api/dreams/save`,
+        path: `/api/dreams/save?apiKey=${encodeURIComponent(apiKey)}`,
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -125,6 +125,7 @@ export async function queryDreamMemories(params: DreamMemoryQuery): Promise<Drea
 
       const queryParams: URLSearchParams = new URLSearchParams();
       queryParams.set("query", params.query);
+      queryParams.set("apiKey", apiKey);
       if (params.project) queryParams.set("project", params.project);
       if (params.limit) queryParams.set("limit", String(params.limit));
       if (params.offset) queryParams.set("offset", String(params.offset));


### PR DESCRIPTION
Replaced `execSync` with `execFileSync` in `src/presentation/mcpServer.ts` to explicitly separate binary arguments and pass to child_process without invoking a shell to prevent command injection vulnerabilities. Also patched `src/services/dreamingService.ts` to correctly populate the `apiKey` URL parameter when making API calls, which passes previously failing test suites. Included journal entry update.

---
*PR created automatically by Jules for task [12387320981316304083](https://jules.google.com/task/12387320981316304083) started by @giauphan*