### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix command injection in git operations

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** Command injection vulnerability in run_script tool
 **Learning:** Input args to script was directly appended to command executed by shell via `execSync`
 **Prevention:** Sanitise input or do not run in shell.
+## 2025-02-14 - Replace execSync with execFileSync to prevent Command Injection
+**Vulnerability:** Use of `child_process.execSync` to run `git` commands leaves the codebase vulnerable to shell command injection if the current working directory path or tool arguments inadvertently contain untrusted characters.
+**Learning:** `execSync` relies on the system shell to execute commands, exposing any interpolation to shell features like `;` or `|`.
+**Prevention:** Use `child_process.execFileSync` (or `spawnSync`) instead of `execSync`, bypassing the shell by explicitly invoking the executable ("git") and passing arguments as an array.

--- a/src/presentation/mcpServer.ts
+++ b/src/presentation/mcpServer.ts
@@ -1917,16 +1917,16 @@ export function registerTools(server: McpServer) {
       const cp = require("child_process");
 
       try {
-        result.branch = cp.execSync("git rev-parse --abbrev-ref HEAD", { cwd: projectDir, encoding: "utf-8" }).toString().trim();
-        const st = cp.execSync("git status --porcelain", { cwd: projectDir, encoding: "utf-8" }).toString();
+        result.branch = cp.execFileSync("git", ["rev-parse", "--abbrev-ref", "HEAD"], { cwd: projectDir, encoding: "utf-8" }).toString().trim();
+        const st = cp.execFileSync("git", ["status", "--porcelain"], { cwd: projectDir, encoding: "utf-8" }).toString();
         const mod: string[] = [], add: string[] = [], del: string[] = [];
         for (const line of st.split("\n").map((x: string) => x.trim()).filter(Boolean)) { const s = line.substring(0, 2), f = line.substring(3); if (s.includes("M")) mod.push(f); if (s.includes("A")) add.push(f); if (s.includes("D")) del.push(f); }
         result.uncommitted = { modified: mod.slice(0, 20), added: add.slice(0, 10), deleted: del.slice(0, 10), hasChanges: st.trim().length > 0 };
         try {
-          const [behind, ahead] = cp.execSync("git rev-list --left-right --count HEAD...@{upstream}", { cwd: projectDir, encoding: "utf-8" }).toString().trim().split("\t").map(Number);
+          const [behind, ahead] = cp.execFileSync("git", ["rev-list", "--left-right", "--count", "HEAD...@{upstream}"], { cwd: projectDir, encoding: "utf-8" }).toString().trim().split("\t").map(Number);
           result.ahead = ahead || 0; result.behind = behind || 0;
         } catch { result.ahead = null; result.behind = null; }
-        const logRaw = cp.execSync(`git log -${maxC} --format="COMMIT%n%H%n%an%n%ai%n%s%nFILES:" --name-only`, { cwd: projectDir, encoding: "utf-8", maxBuffer: 1024 * 1024 }).toString();
+        const logRaw = cp.execFileSync("git", ["log", `-${maxC}`, "--format=COMMIT%n%H%n%an%n%ai%n%s%nFILES:", "--name-only"], { cwd: projectDir, encoding: "utf-8", maxBuffer: 1024 * 1024 }).toString();
         result.recentCommits = [];
         for (const block of logRaw.split("COMMIT\n").filter(Boolean)) {
           const ls = block.trim().split("\n"); if (ls.length < 4) continue;


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Command injection due to using `child_process.execSync` which executes inputs in a shell context.
🎯 Impact: An attacker could potentially inject malicious shell commands (e.g. using `;` or `|`) if user-provided paths or variables end up inside the command string.
🔧 Fix: Replaced `cp.execSync` with `cp.execFileSync` so arguments are passed directly to the `git` executable, bypassing the shell.
✅ Verification: Code successfully compiles and tests pass. No shell interpretation is done for these commands now.

---
*PR created automatically by Jules for task [16119676773125268691](https://jules.google.com/task/16119676773125268691) started by @giauphan*