### PR TITLE
🧹 [Code Health] Extract path resolution to utility functions

### DIFF
--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -10,6 +10,7 @@
 import * as fs from "fs";
 import * as path from "path";
 import * as os from "os";
+import { getHermesConfigPath, getHermesPluginDir } from "../utils/pathUtils.js";
 import * as readline from "readline";
 
 const API_URL = process.env.CODEATLAS_API_URL || "https://your-server.com";
@@ -242,14 +243,14 @@ export async function cmdDoctor(): Promise<void> {
       return { status: "fail", detail: `HTTP ${r.status}` };
     }],
     ["MCP config (Hermes)", async () => {
-      const cfg = path.join(os.homedir(), ".hermes", "config.yaml");
+      const cfg = getHermesConfigPath();
       if (!fs.existsSync(cfg)) return { status: "warn", detail: "not found" };
       const c = fs.readFileSync(cfg, "utf-8");
       if (c.includes("codeatlas:")) return { status: "ok" };
       return { status: "warn", detail: "codeatlas not configured" };
     }],
     ["Auto plugin (Hermes)", async () => {
-      const p = path.join(os.homedir(), ".hermes", "plugins", "codeatlas_second_brain", "__init__.py");
+      const p = path.join(getHermesPluginDir(), "__init__.py");
       return fs.existsSync(p) ? { status: "ok" } : { status: "warn", detail: "not installed" };
     }],
     ["Dream persistence", async () => {

--- a/src/presentation/mcpServer.ts
+++ b/src/presentation/mcpServer.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import * as fs from "fs";
 import * as path from "path";
 import * as os from "os";
+import { getHomePath, getHermesConfigPath, getHermesPluginDir, getClaudeConfigPath } from "../utils/pathUtils.js";
 import { checkAuth, logActivity } from "../services/authService.js";
 import {
   discoverProjectsAsync,
@@ -37,7 +38,7 @@ export function registerTools(server: McpServer) {
 
       // Safety: reject paths that are the user's home directory or system roots
       const resolvedPath = path.resolve(projectPath);
-      const homeDir = os.homedir();
+      const homeDir = getHomePath();
       if (resolvedPath === homeDir || resolvedPath === "/" || resolvedPath === "/home") {
         return { content: [{ type: "text" as const, text: `Error: Refusing to analyze '${resolvedPath}' — path is too broad. Please specify a project subdirectory.` }] };
       }
@@ -1971,7 +1972,7 @@ export function registerTools(server: McpServer) {
 
       // Hermes MCP config
       if (client === "hermes" || client === "all") {
-        const hermesCfg = path.join(os.homedir(), ".hermes", "config.yaml");
+        const hermesCfg = getHermesConfigPath();
         try {
           if (fs.existsSync(hermesCfg)) {
             let cfg = fs.readFileSync(hermesCfg, "utf-8");
@@ -1997,7 +1998,7 @@ export function registerTools(server: McpServer) {
         // Hermes auto plugin
         if (autoPlugin) {
           try {
-            const pluginDir = path.join(os.homedir(), ".hermes", "plugins", "codeatlas_second_brain");
+            const pluginDir = getHermesPluginDir();
             if (!fs.existsSync(pluginDir)) fs.mkdirSync(pluginDir, { recursive: true });
             const pluginInit = `"""CodeAtlas Second Brain Plugin — Auto activation on every turn"""
 import json, urllib.request, urllib.parse, logging
@@ -2068,7 +2069,7 @@ def register(ctx):
 
       // Claude MCP config
       if (client === "claude" || client === "all") {
-        const claudeCfg = path.join(os.homedir(), ".claude", "claude.json");
+        const claudeCfg = getClaudeConfigPath();
         try {
           const claudeEntry = { mcpServers: {
             codeatlas: { command: "npx", args: ["-y", "codeatlas-enterprise"], env: { CODEATLAS_API_KEY: key } },
@@ -2108,18 +2109,18 @@ def register(ctx):
       const results: any = { hermes: {}, claude: {}, gemini: {} };
 
       // Hermes
-      const hermesCfg = path.join(os.homedir(), ".hermes", "config.yaml");
+      const hermesCfg = getHermesConfigPath();
       if (fs.existsSync(hermesCfg)) {
         const cfg = fs.readFileSync(hermesCfg, "utf-8");
         results.hermes.mcp = cfg.includes("codeatlas:") ? "configured" : "not_configured";
       } else {
         results.hermes.mcp = "no_config";
       }
-      const pluginDir = path.join(os.homedir(), ".hermes", "plugins", "codeatlas_second_brain");
+      const pluginDir = getHermesPluginDir();
       results.hermes.plugin = fs.existsSync(path.join(pluginDir, "__init__.py")) ? "installed" : "not_installed";
       results.hermes.restartRequired = results.hermes.plugin === "installed" || results.hermes.mcp === "not_configured";
       // Claude
-      const claudeCfg = path.join(os.homedir(), ".claude", "claude.json");
+      const claudeCfg = getClaudeConfigPath();
       if (fs.existsSync(claudeCfg)) {
         const cl = JSON.parse(fs.readFileSync(claudeCfg, "utf-8"));
         results.claude.mcp = cl.mcpServers?.codeatlas ? "configured" : "not_configured";

--- a/src/services/projectService.ts
+++ b/src/services/projectService.ts
@@ -2,6 +2,7 @@ import * as fs from "fs";
 import * as path from "path";
 import * as https from "https";
 import * as os from "os";
+import { getHomePath } from "../utils/pathUtils.js";
 import { CodeAnalyzer } from "../analyzer/parser.js";
 import { AnalysisResult } from "../analyzer/types.js";
 import { authStorage } from "../context.js";
@@ -199,7 +200,7 @@ export function getWorkspaceFromAncestors(startPid: number = process.pid): strin
 
 export function registerProject(dir: string): void {
   try {
-    const homeDir = os.homedir();
+    const homeDir = getHomePath();
     const configDir = path.join(homeDir, ".codeatlas");
     if (!fs.existsSync(configDir)) {
       fs.mkdirSync(configDir, { recursive: true });
@@ -419,7 +420,7 @@ export function isSystemIdeDirectory(dir: string): boolean {
     }
     
     // Dynamically resolve ~/.gemini/antigravity across operating systems
-    const homeDir = os.homedir();
+    const homeDir = getHomePath();
     const dynamicAntigravityPath = path.resolve(path.join(homeDir, ".gemini", "antigravity"));
     if (absPath === dynamicAntigravityPath || absPath.startsWith(dynamicAntigravityPath + path.sep)) {
       return true;
@@ -634,7 +635,7 @@ export function discoverProjects(tenantId?: string): { name: string; dir: string
 
     // Load globally registered projects
     try {
-      const homeDir = os.homedir();
+      const homeDir = getHomePath();
       const regPath = path.join(homeDir, ".codeatlas", "registered_projects.json");
       if (fs.existsSync(regPath)) {
         const registered = JSON.parse(fs.readFileSync(regPath, "utf-8"));
@@ -796,7 +797,7 @@ export async function discoverProjectsAsync(tenantId?: string): Promise<{ name: 
 
     // Load globally registered projects
     try {
-      const homeDir = os.homedir();
+      const homeDir = getHomePath();
       const regPath = path.join(homeDir, ".codeatlas", "registered_projects.json");
       if (await fileExists(regPath)) {
         const data = await fs.promises.readFile(regPath, "utf-8");
@@ -966,7 +967,7 @@ export function getResolvedApiKey(): string | undefined {
     return key;
   }
 
-  const homeDir = os.homedir();
+  const homeDir = getHomePath();
   const pathsToTry = [
     path.join(homeDir, ".gemini", "antigravity", "mcp_config.json"),
     path.join(homeDir, ".cursor", "mcp.json"),

--- a/src/utils/pathUtils.ts
+++ b/src/utils/pathUtils.ts
@@ -1,0 +1,18 @@
+import * as os from "os";
+import * as path from "path";
+
+export function getHomePath(): string {
+  return os.homedir();
+}
+
+export function getHermesConfigPath(): string {
+  return path.join(getHomePath(), ".hermes", "config.yaml");
+}
+
+export function getHermesPluginDir(): string {
+  return path.join(getHomePath(), ".hermes", "plugins", "codeatlas_second_brain");
+}
+
+export function getClaudeConfigPath(): string {
+  return path.join(getHomePath(), ".claude", "claude.json");
+}


### PR DESCRIPTION
🎯 **What:** Extracted repetitive `path.join(os.homedir(), ...)` logic into shared utility functions in `src/utils/pathUtils.ts`. Updated references in `src/presentation/mcpServer.ts`, `src/cli/commands.ts`, and `src/services/projectService.ts`.
💡 **Why:** Reduces duplicate code, improves maintainability, and makes path handling consistent across the application.
✅ **Verification:** Compiled code successfully, ran `npm run test` with no regressions (32 tests passed).
✨ **Result:** A cleaner codebase with centralized path management.

---
*PR created automatically by Jules for task [9523722981637211200](https://jules.google.com/task/9523722981637211200) started by @giauphan*