### PR TITLE
🛡️ Sentinel: [HIGH] Fix sensitive data exposure in URL parameters

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -3,3 +3,7 @@
 **Learning:** Input args to script was directly appended to command executed by shell via `execSync`
 **Prevention:** Sanitise input or do not run in shell.
 ## 2026-07-13 - Command Injection Risk in execSync\n**Vulnerability:** Use of `child_process.execSync` for git commands allowed potential command injection via the `commits` parameter.\n**Learning:** Even if a parameter seems safe (like a number), using shell execution (`exec`, `execSync`) is inherently risky and can interpret shell metacharacters.\n**Prevention:** Always use `child_process.execFileSync` or `child_process.spawnSync` (with `shell: false`) for executing external binaries. Pass arguments as an array instead of a single string.
+## 2024-07-14 - Sensitive Data Exposure in URL Parameters
+**Vulnerability:** The API key `CODEATLAS_API_KEY` was being sent as a query parameter in URLs within `src/services/dreamingService.ts` when making requests to CodeAtlas Cloud.
+**Learning:** Passing sensitive data like API keys in URL query parameters exposes them to server logs, browser history, and proxy servers (CWE-598).
+**Prevention:** Always transmit API keys and other sensitive credentials securely via HTTP headers (e.g., `x-api-key`, `Authorization: Bearer`), ensuring they are omitted from the request path.

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,7 +2,10 @@
 **Vulnerability:** Command injection vulnerability in run_script tool
 **Learning:** Input args to script was directly appended to command executed by shell via `execSync`
 **Prevention:** Sanitise input or do not run in shell.
-## 2026-07-13 - Command Injection Risk in execSync\n**Vulnerability:** Use of `child_process.execSync` for git commands allowed potential command injection via the `commits` parameter.\n**Learning:** Even if a parameter seems safe (like a number), using shell execution (`exec`, `execSync`) is inherently risky and can interpret shell metacharacters.\n**Prevention:** Always use `child_process.execFileSync` or `child_process.spawnSync` (with `shell: false`) for executing external binaries. Pass arguments as an array instead of a single string.
+## 2026-07-13 - Command Injection Risk in execSync
+**Vulnerability:** Use of `child_process.execSync` for git commands allowed potential command injection via the `commits` parameter.
+**Learning:** Even if a parameter seems safe (like a number), using shell execution (`exec`, `execSync`) is inherently risky and can interpret shell metacharacters.
+**Prevention:** Always use `child_process.execFileSync` or `child_process.spawnSync` (with `shell: false`) for executing external binaries. Pass arguments as an array instead of a single string.
 ## 2026-07-14 - Sensitive Data Exposure in URL Parameters
 **Vulnerability:** The API key `CODEATLAS_API_KEY` was being redundantly sent as a query parameter (alongside the `x-api-key` header) in URLs within `src/services/dreamingService.ts` when making requests to CodeAtlas Cloud.
 **Learning:** Passing sensitive data like API keys in URL query parameters exposes them to server logs, browser history, and proxy servers (CWE-598).

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -4,6 +4,6 @@
 **Prevention:** Sanitise input or do not run in shell.
 ## 2026-07-13 - Command Injection Risk in execSync\n**Vulnerability:** Use of `child_process.execSync` for git commands allowed potential command injection via the `commits` parameter.\n**Learning:** Even if a parameter seems safe (like a number), using shell execution (`exec`, `execSync`) is inherently risky and can interpret shell metacharacters.\n**Prevention:** Always use `child_process.execFileSync` or `child_process.spawnSync` (with `shell: false`) for executing external binaries. Pass arguments as an array instead of a single string.
 ## 2026-07-14 - Sensitive Data Exposure in URL Parameters
-**Vulnerability:** The API key `CODEATLAS_API_KEY` was being sent as a query parameter in URLs within `src/services/dreamingService.ts` when making requests to CodeAtlas Cloud.
+**Vulnerability:** The API key `CODEATLAS_API_KEY` was being redundantly sent as a query parameter (alongside the `x-api-key` header) in URLs within `src/services/dreamingService.ts` when making requests to CodeAtlas Cloud.
 **Learning:** Passing sensitive data like API keys in URL query parameters exposes them to server logs, browser history, and proxy servers (CWE-598).
 **Prevention:** Always transmit API keys and other sensitive credentials securely via HTTP headers (e.g., `x-api-key`, `Authorization: Bearer`), ensuring they are omitted from the request path.

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -3,7 +3,7 @@
 **Learning:** Input args to script was directly appended to command executed by shell via `execSync`
 **Prevention:** Sanitise input or do not run in shell.
 ## 2026-07-13 - Command Injection Risk in execSync\n**Vulnerability:** Use of `child_process.execSync` for git commands allowed potential command injection via the `commits` parameter.\n**Learning:** Even if a parameter seems safe (like a number), using shell execution (`exec`, `execSync`) is inherently risky and can interpret shell metacharacters.\n**Prevention:** Always use `child_process.execFileSync` or `child_process.spawnSync` (with `shell: false`) for executing external binaries. Pass arguments as an array instead of a single string.
-## 2024-07-14 - Sensitive Data Exposure in URL Parameters
+## 2026-07-14 - Sensitive Data Exposure in URL Parameters
 **Vulnerability:** The API key `CODEATLAS_API_KEY` was being sent as a query parameter in URLs within `src/services/dreamingService.ts` when making requests to CodeAtlas Cloud.
 **Learning:** Passing sensitive data like API keys in URL query parameters exposes them to server logs, browser history, and proxy servers (CWE-598).
 **Prevention:** Always transmit API keys and other sensitive credentials securely via HTTP headers (e.g., `x-api-key`, `Authorization: Bearer`), ensuring they are omitted from the request path.

--- a/src/services/dreamingService.test.ts
+++ b/src/services/dreamingService.test.ts
@@ -110,7 +110,7 @@ describe("Dreaming Service - HTTPS Client", () => {
       requestMock = mockSuccessResponse(200, { id: "x" }, capture);
       await dreamingService.saveDreamMemory({ memory_type: "MISTAKE", content: "test" });
       const opts = capture.options!;
-      assert.ok(!String(opts.path).includes("apiKey="), `path should NOT contain apiKey, got: ${opts.path}`);
+      assert.ok(!String(opts.path).includes("apiKey="), `path should NOT contain apiKey, got: ${String(opts.path)}`);
       assert.strictEqual(opts.headers["x-api-key"], "key-sentinel");
     });
 

--- a/src/services/dreamingService.test.ts
+++ b/src/services/dreamingService.test.ts
@@ -104,13 +104,13 @@ describe("Dreaming Service - HTTPS Client", () => {
       assert.strictEqual(parsed.project, "p");
     });
 
-    it("sends apiKey in query param and x-api-key header", async () => {
+    it("sends x-api-key header without exposing apiKey in query param", async () => {
       process.env.CODEATLAS_API_KEY = "key-sentinel";
       const capture: { options?: any; written?: string } = {};
       requestMock = mockSuccessResponse(200, { id: "x" }, capture);
       await dreamingService.saveDreamMemory({ memory_type: "MISTAKE", content: "test" });
       const opts = capture.options!;
-      assert.ok(String(opts.path).includes("apiKey=key-sentinel"), `path should contain apiKey, got: ${opts.path}`);
+      assert.ok(!String(opts.path).includes("apiKey="), `path should NOT contain apiKey, got: ${opts.path}`);
       assert.strictEqual(opts.headers["x-api-key"], "key-sentinel");
     });
 
@@ -180,13 +180,13 @@ describe("Dreaming Service - HTTPS Client", () => {
       assert.ok(!String(capture.options!.path).includes("limit="));
     });
 
-    it("includes apiKey in query params and x-api-key header for GET", async () => {
+    it("includes x-api-key header for GET without exposing apiKey in query param", async () => {
       process.env.CODEATLAS_API_KEY = "test-key-query";
       const capture: { options?: any } = {};
       requestMock = mockSuccessResponse(200, { memories: [] }, capture);
       await dreamingService.queryDreamMemories({ query: "test" });
       const path = String(capture.options!.path);
-      assert.ok(path.includes("apiKey=test-key-query"), `Expected apiKey in query, got: ${path}`);
+      assert.ok(!path.includes("apiKey="), `Expected apiKey to NOT be in query, got: ${path}`);
       assert.strictEqual(capture.options!.headers["x-api-key"], "test-key-query");
     });
 

--- a/src/services/dreamingService.ts
+++ b/src/services/dreamingService.ts
@@ -53,7 +53,7 @@ export async function saveDreamMemory(params: DreamMemoryInput): Promise<{ succe
       const options: https.RequestOptions = {
         hostname: serverUrl.hostname,
         port: serverUrl.port || (serverUrl.protocol === "https:" ? 443 : 80),
-        path: `/api/dreams/save?apiKey=${encodeURIComponent(apiKey)}`,
+        path: `/api/dreams/save`,
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -128,7 +128,6 @@ export async function queryDreamMemories(params: DreamMemoryQuery): Promise<Drea
       if (params.project) queryParams.set("project", params.project);
       if (params.limit) queryParams.set("limit", String(params.limit));
       if (params.offset) queryParams.set("offset", String(params.offset));
-      queryParams.set("apiKey", apiKey);
 
       const options: https.RequestOptions = {
         hostname: serverUrl.hostname,

--- a/src/services/dreamingService.ts
+++ b/src/services/dreamingService.ts
@@ -53,7 +53,7 @@ export async function saveDreamMemory(params: DreamMemoryInput): Promise<{ succe
       const options: https.RequestOptions = {
         hostname: serverUrl.hostname,
         port: serverUrl.port || (serverUrl.protocol === "https:" ? 443 : 80),
-        path: `/api/dreams/save`,
+        path: "/api/dreams/save",
         method: "POST",
         headers: {
           "Content-Type": "application/json",


### PR DESCRIPTION
* 🚨 **Severity:** HIGH
* 💡 **Vulnerability:** Sensitive Data Exposure in URL (CWE-598). The `CODEATLAS_API_KEY` was being sent as a query parameter in URLs within `src/services/dreamingService.ts` when making requests to CodeAtlas Cloud.
* 🎯 **Impact:** API keys in URL query strings can be exposed through server logs, proxy logs, and browser history, allowing attackers to intercept and misuse the credentials.
* 🔧 **Fix:** Removed the `apiKey` query parameter from the `saveDreamMemory` and `queryDreamMemories` functions. The application now correctly and exclusively transmits the API key using the `x-api-key` HTTP header.
* ✅ **Verification:** Run `npm test`. The unit tests in `src/services/dreamingService.test.ts` have been updated to explicitly assert that `apiKey` is *not* present in the URL query string, and only present in the `x-api-key` header. All tests pass successfully.

---
*PR created automatically by Jules for task [917224748005285545](https://jules.google.com/task/917224748005285545) started by @giauphan*