### PR TITLE
🛡️ Sentinel: [HIGH] Fix authorization bypass in API

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -10,3 +10,7 @@
 **Vulnerability:** The API key `CODEATLAS_API_KEY` was being redundantly sent as a query parameter (alongside the `x-api-key` header) in URLs within `src/services/dreamingService.ts` when making requests to CodeAtlas Cloud.
 **Learning:** Passing sensitive data like API keys in URL query parameters exposes them to server logs, browser history, and proxy servers (CWE-598).
 **Prevention:** Always transmit API keys and other sensitive credentials securely via HTTP headers (e.g., `x-api-key`, `Authorization: Bearer`), ensuring they are omitted from the request path.
+## 2026-07-15 - Authorization Bypass Risk in Local Mock Fallbacks
+**Vulnerability:** The `checkAuth` function used for multi-tenant authorization fell back to granting full 'enterprise' privileges via a mock local user if no authentication context was found.
+**Learning:** When software supports both single-tenant (local) and multi-tenant (cloud) deployment modes, mock security fallbacks designed for local development can inadvertently bypass authentication in production if they are not conditionally gated.
+**Prevention:** Always check deployment/configuration flags (e.g., `CODEATLAS_MULTI_TENANT`) before returning mock credentials or bypassing security checks. Throw an explicit unauthorized error when running in a multi-tenant environment.

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -9,7 +9,8 @@ export async function checkAuth(apiKey?: string): Promise<{ tier: string; uid: s
     return contextAuth;
   }
 
-  if (process.env.CODEATLAS_MULTI_TENANT === "true") {
+  const multiTenant = process.env.CODEATLAS_MULTI_TENANT;
+  if (multiTenant === "true" || multiTenant === "1") {
     throw new Error("Unauthorized: Missing tenant authentication context.");
   }
 

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -8,6 +8,11 @@ export async function checkAuth(apiKey?: string): Promise<{ tier: string; uid: s
   if (contextAuth) {
     return contextAuth;
   }
+
+  if (process.env.CODEATLAS_MULTI_TENANT === "true") {
+    throw new Error("Unauthorized: Missing tenant authentication context.");
+  }
+
   return {
     tier: "enterprise",
     uid: "local-user",

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -5,7 +5,7 @@ import { authStorage } from "../context.js";
  */
 export async function checkAuth(apiKey?: string): Promise<{ tier: string; uid: string; keyId: string }> {
   const contextAuth = authStorage.getStore();
-  if (contextAuth) {
+  if (contextAuth && Object.keys(contextAuth).length > 0) {
     return contextAuth;
   }
 


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The `checkAuth` function for multi-tenant authorization fell back to granting full 'enterprise' privileges via a mock local user if no authentication context was found.
🎯 **Impact:** When the software was deployed in multi-tenant mode (cloud), the mock security fallback intended for local development bypassed authentication completely, granting unauthorized requests full administrative capabilities.
🔧 **Fix:** Added a conditional check for the `CODEATLAS_MULTI_TENANT` deployment flag in `src/services/authService.ts`. If running in multi-tenant mode without valid auth context, it now throws an explicit `Unauthorized` error instead of returning local mock credentials.
✅ **Verification:** Verified by running `npm run build` and `npm run test` to ensure existing functionality remains working locally. Checked logic to ensure the `Unauthorized` error correctly gates access when `CODEATLAS_MULTI_TENANT` is enabled.

---
*PR created automatically by Jules for task [13244231966475233043](https://jules.google.com/task/13244231966475233043) started by @giauphan*