### PR TITLE
⚡ Bolt: [Performance improvement] Optimize project discovery with fs.readdir withFileTypes

### DIFF
--- a/src/services/projectService.ts
+++ b/src/services/projectService.ts
@@ -604,10 +604,18 @@ export function discoverProjects(tenantId?: string): { name: string; dir: string
       const userDir = path.join(tenantRoot, tenantId);
       if (fs.existsSync(userDir)) {
         try {
-          const userProjects = fs.readdirSync(userDir);
-          for (const p of userProjects) {
-            const fullPath = path.join(userDir, p);
-            if (fs.statSync(fullPath).isDirectory()) {
+          const userProjects = fs.readdirSync(userDir, { withFileTypes: true });
+          for (const entry of userProjects) {
+            const fullPath = path.join(userDir, entry.name);
+            let isDirectory = entry.isDirectory();
+            if (!isDirectory && entry.isSymbolicLink()) {
+              try {
+                isDirectory = fs.statSync(fullPath).isDirectory();
+              } catch {
+                continue;
+              }
+            }
+            if (isDirectory) {
               searchDirs.push(fullPath);
             }
           }
@@ -763,15 +771,21 @@ export async function discoverProjectsAsync(tenantId?: string): Promise<{ name: 
       const userDir = path.join(tenantRoot, tenantId);
       if (await fileExists(userDir)) {
         try {
-          const userProjects = await fs.promises.readdir(userDir);
-          const statPromises = userProjects.map(async (p) => {
-            const fullPath = path.join(userDir, p);
-            try {
-              const stat = await fs.promises.stat(fullPath);
-              if (stat.isDirectory()) {
-                searchDirs.push(fullPath);
+          const userProjects = await fs.promises.readdir(userDir, { withFileTypes: true });
+          const statPromises = userProjects.map(async (entry) => {
+            const fullPath = path.join(userDir, entry.name);
+            let isDirectory = entry.isDirectory();
+            if (!isDirectory && entry.isSymbolicLink()) {
+              try {
+                const stat = await fs.promises.stat(fullPath);
+                isDirectory = stat.isDirectory();
+              } catch {
+                return;
               }
-            } catch { /* skip */ }
+            }
+            if (isDirectory) {
+              searchDirs.push(fullPath);
+            }
           });
           await Promise.all(statPromises);
         } catch { /* skip */ }


### PR DESCRIPTION
💡 What: The `discoverProjects` and `discoverProjectsAsync` functions used `fs.readdir` (which returned string names), and subsequently mapped those strings into absolute paths to check via N+1 synchronous (`fs.statSync`) and asynchronous (`fs.promises.stat`) `stat` operations. This optimization changes them to use `{ withFileTypes: true }`, bypassing the costly loop of disk calls.
🎯 Why: Iterating over many directories on an I/O constrained storage system blocks the node thread or overloads the I/O bus unnecessarily. Retrieving directory state alongside the read command scales exponentially better.
📊 Impact: This significantly cuts down the amount of disk I/O when discovering multi-tenant repositories in directories containing large numbers of users. Avoids N+1 system calls per project user space folder.
🔬 Measurement: Verify changes in execution length when running discovery across thousands of subdirectories by utilizing local timing functions. Ensure memory impact stays stable.

---
*PR created automatically by Jules for task [6302775531672019477](https://jules.google.com/task/6302775531672019477) started by @giauphan*