### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix YAML injection vulnerability in MCP setup

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -14,3 +14,7 @@
 **Vulnerability:** The `checkAuth` function used for multi-tenant authorization fell back to granting full 'enterprise' privileges via a mock local user if no authentication context was found.
 **Learning:** When software supports both single-tenant (local) and multi-tenant (cloud) deployment modes, mock security fallbacks designed for local development can inadvertently bypass authentication in production if they are not conditionally gated.
 **Prevention:** Always check deployment/configuration flags (e.g., `CODEATLAS_MULTI_TENANT`) before returning mock credentials or bypassing security checks. Throw an explicit unauthorized error when running in a multi-tenant environment.
+## 2026-07-16 - YAML Injection in MCP Server Configuration
+**Vulnerability:** The `CODEATLAS_API_KEY` was being interpolated directly into a YAML string via a template literal (`"${key}"`), which exposed the configuration to YAML injection if the key contained double quotes and newline characters.
+**Learning:** Interpolating unvalidated input strings into YAML without proper escaping creates a risk of structural injection, potentially allowing an attacker to overwrite configuration blocks or execute arbitrary commands.
+**Prevention:** Always use `JSON.stringify(key)` instead of raw string interpolation (`"${key}"`) when injecting string values into generated YAML or JSON configuration blocks to securely escape quotes and newlines.

--- a/src/presentation/mcpServer.ts
+++ b/src/presentation/mcpServer.ts
@@ -1986,7 +1986,8 @@ export function registerTools(server: McpServer) {
       }, null, 2) }] };
 
       const results: any[] = [];
-      const mcpEntry = `  codeatlas:\n    command: npx\n    args: ["-y", "codeatlas-enterprise"]\n    env:\n      CODEATLAS_API_KEY: "${key}"\n    enabled: true\n`;
+      // Use JSON.stringify to safely escape double quotes and newlines to prevent YAML injection
+      const mcpEntry = `  codeatlas:\n    command: npx\n    args: ["-y", "codeatlas-enterprise"]\n    env:\n      CODEATLAS_API_KEY: ${JSON.stringify(key)}\n    enabled: true\n`;
 
       // Hermes MCP config
       if (client === "hermes" || client === "all") {


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** YAML injection vulnerability in `src/presentation/mcpServer.ts` within the `setup_second_brain` tool. The `CODEATLAS_API_KEY` was being interpolated directly into a YAML string without escaping, which could allow a malicious user to inject arbitrary YAML nodes by providing an API key containing double quotes and newlines.
🎯 **Impact:** Structural configuration injection, which could lead to arbitrary command execution during MCP client configuration and startup.
🔧 **Fix:** Changed the interpolation of `key` from `"${key}"` to `${JSON.stringify(key)}`, which safely encodes the input string and neutralizes any structural characters.
✅ **Verification:** Verified that tests pass via `npm run test` and `npm run build` and recorded the finding in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [17839039152117133710](https://jules.google.com/task/17839039152117133710) started by @giauphan*