### PR TITLE
🔒 Fix API key exposure in doctor command

### DIFF
--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -123,7 +123,7 @@ export async function cmdDoctor(): Promise<void> {
 
   const checks: [string, () => Promise<{ status: string; detail?: string }>][] = [
     ["CODEATLAS_API_KEY", async () => {
-      if (process.env.CODEATLAS_API_KEY) return { status: "ok", detail: `${process.env.CODEATLAS_API_KEY.substring(0, 8)}...` };
+      if (process.env.CODEATLAS_API_KEY) return { status: "ok", detail: `***` };
       return { status: "fail", detail: "not set" };
     }],
     ["Cloud connection", async () => {


### PR DESCRIPTION
🎯 **What:** The `CODEATLAS_API_KEY` was partially exposed in the terminal output when running the CLI doctor/health check commands.
⚠️ **Risk:** Leaking the first 8 characters of an API key is a security vulnerability, as it exposes part of the credential in local terminal outputs or shared logs.
🛡️ **Solution:** Replaced the substring output of the API key with `***` to safely indicate that the key is set without revealing any of its characters.

---
*PR created automatically by Jules for task [1349427236753461622](https://jules.google.com/task/1349427236753461622) started by @giauphan*