### PR TITLE
🔒 Fix Path Traversal in getResolvedApiKey configuration loader

### DIFF
--- a/src/services/projectService.ts
+++ b/src/services/projectService.ts
@@ -985,6 +985,9 @@ export function getResolvedApiKey(): string | undefined {
 
   for (const filePath of pathsToTry) {
     try {
+      if (filePath.indexOf('\0') !== -1 || filePath.includes('..')) {
+        continue;
+      }
       if (fs.existsSync(filePath)) {
         const content = fs.readFileSync(filePath, "utf8");
         const parsed = JSON.parse(content);


### PR DESCRIPTION
🎯 **What:** A path traversal vulnerability existed in the `loadAnalysisAsync`/`getResolvedApiKey` loop where dynamically resolved paths were checked and read without validating whether they contain directory traversal (`..`) sequences or null bytes.

⚠️ **Risk:** An attacker or malicious input could potentially exploit this behavior to force the application to read arbitrary files off the file system, bypassing the intended `.config` or `.gemini` paths, potentially exposing sensitive information or secrets.

🛡️ **Solution:** Added a safeguard `if (filePath.indexOf('\0') !== -1 || filePath.includes('..')) { continue; }` before the `fs.existsSync` and `fs.readFileSync` calls. This ensures any malformed paths are safely ignored and the loop continues naturally.

---
*PR created automatically by Jules for task [10417844403573451939](https://jules.google.com/task/10417844403573451939) started by @giauphan*