### PR TITLE
🔒 Fix npm argument injection in run_script

### DIFF
--- a/src/presentation/mcpServer.ts
+++ b/src/presentation/mcpServer.ts
@@ -1889,8 +1889,29 @@ export function registerTools(server: McpServer) {
 
       try {
         const cp = require("child_process");
-        const parsedArgs = args ? args.split(" ").filter(Boolean) : [];
-        const result = cp.spawnSync("npm", ["run", script, ...parsedArgs], {
+        let parsedArgs: string[] = [];
+        if (args) {
+          const match = args.match(/(?:[^\s"']+|"[^"]*"|'[^']*')+/g);
+          if (match) {
+            parsedArgs = match.map(m => {
+              if ((m.startsWith('"') && m.endsWith('"')) || (m.startsWith("'") && m.endsWith("'"))) {
+                return m.substring(1, m.length - 1);
+              }
+              return m;
+            });
+          }
+        }
+
+        // Security: Prevent npm argument injection (e.g. --prefix) by forcing all args to be passed to the script
+        const finalArgs = ["run", script];
+        if (parsedArgs.length > 0) {
+          if (parsedArgs[0] !== "--") {
+            finalArgs.push("--");
+          }
+          finalArgs.push(...parsedArgs);
+        }
+
+        const result = cp.spawnSync("npm", finalArgs, {
           timeout: maxTime * 1000,
           shell: false, // Security: explicit shell false
           maxBuffer: 1024 * 1024,


### PR DESCRIPTION
🎯 **What:** The `run_script` tool passed unsanitized and loosely parsed `args` to `cp.spawnSync` via `["run", script, ...parsedArgs]`. While `shell: false` prevented shell injection (`&&`, `|`, etc.), an attacker could pass npm-specific flags such as `--prefix /tmp` or `--workspace`, leading to Argument Injection where the script is executed in unintended contexts. Additionally, argument string splitting on spaces `args.split(" ")` meant quoted arguments were corrupted.
  
⚠️ **Risk:** Medium. An attacker could manipulate the `npm` CLI itself by injecting npm options like `--prefix /path/to/malicious/package` to execute unintended code if it exists.

🛡️ **Solution:**
- The arguments string is now parsed using a RegEx to handle quotes correctly, improving functionality.
- We ensure that if user arguments are passed, they are prepended with `--`. This explicitly tells `npm` that all following arguments should be passed to the run script and not interpreted as flags for `npm` itself.

---
*PR created automatically by Jules for task [7252742565550695405](https://jules.google.com/task/7252742565550695405) started by @giauphan*