### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix YAML injection

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -14,3 +14,7 @@
 **Vulnerability:** The `checkAuth` function used for multi-tenant authorization fell back to granting full 'enterprise' privileges via a mock local user if no authentication context was found.
 **Learning:** When software supports both single-tenant (local) and multi-tenant (cloud) deployment modes, mock security fallbacks designed for local development can inadvertently bypass authentication in production if they are not conditionally gated.
 **Prevention:** Always check deployment/configuration flags (e.g., `CODEATLAS_MULTI_TENANT`) before returning mock credentials or bypassing security checks. Throw an explicit unauthorized error when running in a multi-tenant environment.
+## 2024-07-18 - [YAML Injection Risk in Configuration Generator]
+**Vulnerability:** The `CODEATLAS_API_KEY` was directly interpolated into a YAML string using string interpolation and double quotes (`"${key}"`).
+**Learning:** Directly embedding strings into structured data formats like YAML or JSON can lead to injection vulnerabilities if the string contains quotes or newlines.
+**Prevention:** Always use `JSON.stringify(value)` to securely escape variables when generating YAML or JSON configuration strings programmatically.

--- a/src/presentation/mcpServer.ts
+++ b/src/presentation/mcpServer.ts
@@ -1986,7 +1986,7 @@ export function registerTools(server: McpServer) {
       }, null, 2) }] };
 
       const results: any[] = [];
-      const mcpEntry = `  codeatlas:\n    command: npx\n    args: ["-y", "codeatlas-enterprise"]\n    env:\n      CODEATLAS_API_KEY: "${key}"\n    enabled: true\n`;
+      const mcpEntry = `  codeatlas:\n    command: npx\n    args: ["-y", "codeatlas-enterprise"]\n    env:\n      CODEATLAS_API_KEY: ${JSON.stringify(key)}\n    enabled: true\n`;
 
       // Hermes MCP config
       if (client === "hermes" || client === "all") {


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The `CODEATLAS_API_KEY` was directly interpolated into a YAML string using double quotes. A maliciously crafted or malformed API key could inject structural elements into the generated YAML configurations, potentially leading to unauthorized configuration parameters or breaking the configuration files entirely.
🎯 **Impact:** If exploited or given a malformed key, could corrupt the MCP client configuration files (Hermes/Claude), leading to system unavailability or unexpected behavior from injection.
🔧 **Fix:** Refactored the `setup_second_brain` command in `src/presentation/mcpServer.ts` to use `JSON.stringify(key)` for safe escaping and structural integrity in the resulting configuration file.
✅ **Verification:** Verified by running `npm run build` and `npm test` ensuring existing logic works without regression and the injection issue is handled cleanly. Also appended learning to Sentinel journal as instructed.

---
*PR created automatically by Jules for task [5010279905233468197](https://jules.google.com/task/5010279905233468197) started by @giauphan*