### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix DoS vulnerability by adding string length limits to run_script tool

### DIFF
--- a/src/presentation/mcpServer.ts
+++ b/src/presentation/mcpServer.ts
@@ -1913,9 +1913,9 @@ export function registerTools(server: McpServer) {
     "run_script",
     "Run an npm/pnpm/yarn script from package.json. Returns exit code, stdout/stderr, and duration. Handles cd to project dir automatically.",
     {
-      project: z.string().optional().describe("Project name or path"),
-      script: z.string().describe("Script name from package.json (e.g. 'build', 'test', 'lint')"),
-      args: z.string().optional().describe("Optional args (e.g. '-- --watch')"),
+      project: z.string().max(255).optional().describe("Project name or path"),
+      script: z.string().max(100).describe("Script name from package.json (e.g. 'build', 'test', 'lint')"),
+      args: z.string().max(1000).optional().describe("Optional args (e.g. '-- --watch')"),
       timeout: z.number().optional().describe("Timeout in seconds (default: 60, max: 300)"),
     },
     async ({ project, script, args, timeout }: { project?: string; script: string; args?: string; timeout?: number }) => {


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Denial of Service (DoS) risk due to missing input length limits on the `run_script` tool's string parameters. Attackers could send excessively large string payloads to cause resource exhaustion.
🎯 **Impact:** High memory consumption, CPU spikes, or crashing of the MCP server.
🔧 **Fix:** Added `.max()` validation constraints to the Zod schema for `project`, `script`, and `args` parameters in `src/presentation/mcpServer.ts`.
✅ **Verification:** Verified via test suite (`npm run test`) and code review that standard use cases are unaffected and inputs are now constrained.

---
*PR created automatically by Jules for task [17131324405789117036](https://jules.google.com/task/17131324405789117036) started by @giauphan*