### PR TITLE
🔒 Prevent path traversal in project loading and command execution

### DIFF
--- a/src/presentation/mcpServer.ts
+++ b/src/presentation/mcpServer.ts
@@ -7,6 +7,7 @@ import { getHomePath, getHermesConfigPath, getHermesPluginDir, getClaudeConfigPa
 import { checkAuth, logActivity } from "../services/authService.js";
 import {
   discoverProjectsAsync,
+  isPathInAuthorizedProjects,
   loadAnalysisAsync,
   getStats,
   fileExists,
@@ -1930,12 +1931,7 @@ export function registerTools(server: McpServer) {
 
       // Ensure the project directory is an authorized workspace to prevent path traversal
       const authorizedProjects = await discoverProjectsAsync(auth.uid);
-      const isAuthorized = authorizedProjects.some(p => {
-        const resolvedProj = fs.realpathSync(path.resolve(projectDir));
-        const resolvedAuth = fs.realpathSync(path.resolve(p.dir));
-        return resolvedProj === resolvedAuth || resolvedProj.startsWith(resolvedAuth + path.sep);
-      });
-      if (!isAuthorized) {
+      if (!isPathInAuthorizedProjects(projectDir, authorizedProjects)) {
         return { content: [{ type: "text" as const, text: JSON.stringify({ error: "Unauthorized project directory" }) }] };
       }
 
@@ -2021,12 +2017,7 @@ export function registerTools(server: McpServer) {
       // 🛡️ Sentinel Security Validation
       // Ensure the project directory is an authorized workspace to prevent path traversal
       const authorizedProjects = await discoverProjectsAsync(auth.uid);
-      const isAuthorized = authorizedProjects.some(p => {
-        const resolvedProj = fs.realpathSync(path.resolve(projectDir));
-        const resolvedAuth = fs.realpathSync(path.resolve(p.dir));
-        return resolvedProj === resolvedAuth || resolvedProj.startsWith(resolvedAuth + path.sep);
-      });
-      if (!isAuthorized) {
+      if (!isPathInAuthorizedProjects(projectDir, authorizedProjects)) {
         return { content: [{ type: "text" as const, text: JSON.stringify({ error: "Unauthorized project directory" }) }] };
       }
 

--- a/src/presentation/mcpServer.ts
+++ b/src/presentation/mcpServer.ts
@@ -1930,9 +1930,11 @@ export function registerTools(server: McpServer) {
 
       // Ensure the project directory is an authorized workspace to prevent path traversal
       const authorizedProjects = await discoverProjectsAsync(auth.uid);
-      const isAuthorized = authorizedProjects.some(p =>
-        projectDir === p.dir || projectDir.startsWith(p.dir + path.sep)
-      );
+      const isAuthorized = authorizedProjects.some(p => {
+        const resolvedProj = fs.realpathSync(path.resolve(projectDir));
+        const resolvedAuth = fs.realpathSync(path.resolve(p.dir));
+        return resolvedProj === resolvedAuth || resolvedProj.startsWith(resolvedAuth + path.sep);
+      });
       if (!isAuthorized) {
         return { content: [{ type: "text" as const, text: JSON.stringify({ error: "Unauthorized project directory" }) }] };
       }
@@ -2019,9 +2021,11 @@ export function registerTools(server: McpServer) {
       // 🛡️ Sentinel Security Validation
       // Ensure the project directory is an authorized workspace to prevent path traversal
       const authorizedProjects = await discoverProjectsAsync(auth.uid);
-      const isAuthorized = authorizedProjects.some(p =>
-        projectDir === p.dir || projectDir.startsWith(p.dir + path.sep)
-      );
+      const isAuthorized = authorizedProjects.some(p => {
+        const resolvedProj = fs.realpathSync(path.resolve(projectDir));
+        const resolvedAuth = fs.realpathSync(path.resolve(p.dir));
+        return resolvedProj === resolvedAuth || resolvedProj.startsWith(resolvedAuth + path.sep);
+      });
       if (!isAuthorized) {
         return { content: [{ type: "text" as const, text: JSON.stringify({ error: "Unauthorized project directory" }) }] };
       }

--- a/src/presentation/mcpServer.ts
+++ b/src/presentation/mcpServer.ts
@@ -1927,6 +1927,16 @@ export function registerTools(server: McpServer) {
       // 🛡️ Sentinel Security Validation
       // Use spawnSync without a shell to prevent command injection entirely
       const projectDir = loaded.projectDir;
+
+      // Ensure the project directory is an authorized workspace to prevent path traversal
+      const authorizedProjects = await discoverProjectsAsync(auth.uid);
+      const isAuthorized = authorizedProjects.some(p =>
+        projectDir === p.dir || projectDir.startsWith(p.dir + path.sep)
+      );
+      if (!isAuthorized) {
+        return { content: [{ type: "text" as const, text: JSON.stringify({ error: "Unauthorized project directory" }) }] };
+      }
+
       const pkgPath = path.join(projectDir, "package.json");
       if (fs.existsSync(pkgPath)) {
         try {

--- a/src/services/projectService.ts
+++ b/src/services/projectService.ts
@@ -895,6 +895,12 @@ export async function loadAnalysisAsync(
       target = match;
       registerProject(target.dir);
     } else if (await isProjectDirectoryAsync(absPath)) {
+      // Security Validation: Ensure the loaded path is inside an authorized workspace
+      const isAuthorized = projects.some(p => absPath === p.dir || absPath.startsWith(p.dir + path.sep));
+      if (!isAuthorized) {
+        console.error(`[Auto-Scan] 🛡️ Blocked unauthorized access to directory outside workspace: ${absPath}`);
+        return null;
+      }
       registerProject(absPath);
       target = {
         name: path.basename(absPath),

--- a/src/services/projectService.ts
+++ b/src/services/projectService.ts
@@ -17,6 +17,28 @@ export const fsWrapper = {
   readdirSync: (p: string) => fs.readdirSync(p)
 };
 
+/**
+ * Validates if a target path is safely contained within an authorized workspace path.
+ * Resolves symlinks and normalizes paths before comparison to prevent path traversal.
+ */
+export function isPathInAuthorizedProjects(targetPath: string, authorizedProjects: { dir: string }[]): boolean {
+  let resolvedTarget: string;
+  try {
+    resolvedTarget = fs.realpathSync(path.resolve(targetPath));
+  } catch (err) {
+    return false;
+  }
+
+  return authorizedProjects.some(p => {
+    try {
+      const resolvedAuth = fs.realpathSync(path.resolve(p.dir));
+      return resolvedTarget === resolvedAuth || resolvedTarget.startsWith(resolvedAuth + path.sep);
+    } catch {
+      return false;
+    }
+  });
+}
+
 /** Unified stats helper */
 export function getStats(analysis: AnalysisResultLocal) {
   const ec = analysis.entityCounts;
@@ -896,23 +918,7 @@ export async function loadAnalysisAsync(
       registerProject(target.dir);
     } else if (await isProjectDirectoryAsync(absPath)) {
       // Security Validation: Ensure the loaded path is inside an authorized workspace
-      let resolvedAbsPath: string;
-      try {
-        resolvedAbsPath = fs.realpathSync(absPath);
-      } catch (err) {
-        console.error(`[Auto-Scan] ⚠️ Could not resolve path ${absPath}:`, err);
-        return null;
-      }
-
-      const isAuthorized = projects.some(p => {
-        try {
-          const resolvedAuth = fs.realpathSync(path.resolve(p.dir));
-          return resolvedAbsPath === resolvedAuth || resolvedAbsPath.startsWith(resolvedAuth + path.sep);
-        } catch {
-          return false;
-        }
-      });
-      if (!isAuthorized) {
+      if (!isPathInAuthorizedProjects(absPath, projects)) {
         console.error(`[Auto-Scan] 🛡️ Blocked unauthorized access to directory outside workspace: ${absPath}`);
         return null;
       }

--- a/src/services/projectService.ts
+++ b/src/services/projectService.ts
@@ -896,7 +896,22 @@ export async function loadAnalysisAsync(
       registerProject(target.dir);
     } else if (await isProjectDirectoryAsync(absPath)) {
       // Security Validation: Ensure the loaded path is inside an authorized workspace
-      const isAuthorized = projects.some(p => absPath === p.dir || absPath.startsWith(p.dir + path.sep));
+      let resolvedAbsPath: string;
+      try {
+        resolvedAbsPath = fs.realpathSync(absPath);
+      } catch (err) {
+        console.error(`[Auto-Scan] ⚠️ Could not resolve path ${absPath}:`, err);
+        return null;
+      }
+
+      const isAuthorized = projects.some(p => {
+        try {
+          const resolvedAuth = fs.realpathSync(path.resolve(p.dir));
+          return resolvedAbsPath === resolvedAuth || resolvedAbsPath.startsWith(resolvedAuth + path.sep);
+        } catch {
+          return false;
+        }
+      });
       if (!isAuthorized) {
         console.error(`[Auto-Scan] 🛡️ Blocked unauthorized access to directory outside workspace: ${absPath}`);
         return null;


### PR DESCRIPTION
🎯 **What:** 
Fixed a critical security vulnerability involving path traversal and potential command execution outside user's authorized workspaces in the MCP tool handlers.

⚠️ **Risk:** 
If left unfixed, an attacker could supply an arbitrary directory path as `project` to `loadAnalysisAsync` or `run_script`, and the server would resolve the path and potentially execute commands (e.g. `npm build`, `git status`) in unauthorized directories (such as system paths or other tenant's environments). This can result in unauthorized reading of files, sensitive data exposure, and arbitrary command execution.

🛡️ **Solution:** 
- Enforced boundary checks inside `loadAnalysisAsync` (in `src/services/projectService.ts`) to ensure that any target directory falls within the list of authorized projects returned by `discoverProjectsAsync`.
- Replicated this robust security boundary check directly into the `run_script` tool in `src/presentation/mcpServer.ts` for defense in depth.

---
*PR created automatically by Jules for task [13559946412106956244](https://jules.google.com/task/13559946412106956244) started by @giauphan*