### PR TITLE
🔒 Fix indirect command injection in run_script tool via args

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -18,3 +18,7 @@
 **Vulnerability:** The `CODEATLAS_API_KEY` was directly interpolated into a YAML string using string interpolation and double quotes (`"${key}"`).
 **Learning:** Directly embedding strings into structured data formats like YAML or JSON can lead to injection vulnerabilities if the string contains quotes or newlines.
 **Prevention:** Always use `JSON.stringify(value)` to securely escape variables when generating YAML or JSON configuration strings programmatically.
+## 2026-07-22 - [Indirect Command Injection]
+**Vulnerability:** Indirect command injection vulnerability in `run_script` tool via arguments passed to `npm run` which executes the target script in a shell environment.
+**Learning:** Even when `spawnSync` is used with `shell: false`, passing untrusted arguments to commands like `npm run` (which in turn launch subshells) can lead to command injection if the arguments are appended directly to the target script and contain shell metacharacters.
+**Prevention:** Strictly validate or sanitize untrusted input destined for command-line arguments by blocking shell metacharacters (`&|;<>$`\n\r`) before passing them to process executors.

--- a/src/presentation/mcpServer.ts
+++ b/src/presentation/mcpServer.ts
@@ -23,6 +23,8 @@ function escapeRegExp(str: string): string {
   return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
+const SHELL_METACHAR_RE = /[&|;<>$`\\\n\r]/;
+
 export function registerTools(server: McpServer) {
   // Tool -1: Analyze a project
   server.tool(
@@ -1943,8 +1945,9 @@ export function registerTools(server: McpServer) {
         let parsedArgs: string[] = [];
         if (args) {
           // Security: Block shell metacharacters to prevent indirect command injection in the target script
-          if (/[&|;<>$`\\\n\r]/.test(args)) {
-            return { content: [{ type: "text" as const, text: JSON.stringify({ error: "Security Error: Arguments contain forbidden shell metacharacters" }, null, 2) }] };
+          if (SHELL_METACHAR_RE.test(args)) {
+            const truncatedArgs = args.length > 50 ? args.substring(0, 50) + "..." : args;
+            return { content: [{ type: "text" as const, text: JSON.stringify({ error: `Security Error: Arguments contain forbidden shell metacharacters (& | ; < > $ \` \\). Received: ${truncatedArgs}` }, null, 2) }] };
           }
           const match = args.match(/(?:[^\s"']+|"[^"]*"|'[^']*')+/g);
           if (match) {

--- a/src/presentation/mcpServer.ts
+++ b/src/presentation/mcpServer.ts
@@ -1942,6 +1942,10 @@ export function registerTools(server: McpServer) {
         const cp = require("child_process");
         let parsedArgs: string[] = [];
         if (args) {
+          // Security: Block shell metacharacters to prevent indirect command injection in the target script
+          if (/[&|;<>$`\\\n\r]/.test(args)) {
+            return { content: [{ type: "text" as const, text: JSON.stringify({ error: "Security Error: Arguments contain forbidden shell metacharacters" }, null, 2) }] };
+          }
           const match = args.match(/(?:[^\s"']+|"[^"]*"|'[^']*')+/g);
           if (match) {
             parsedArgs = match.map(m => {


### PR DESCRIPTION
🎯 **What:** Fixed an indirect command injection vulnerability in the `run_script` tool by blocking shell metacharacters in the `args` parameter.

⚠️ **Risk:** Although `spawnSync` was used with `shell: false`, arguments passed to `npm run` are evaluated by the shell when npm executes the actual target script. This allowed an attacker to inject shell commands via the args string. If exploited, it could lead to arbitrary command execution on the host machine.

🛡️ **Solution:** Implemented a regex allowlist (`/[&|;<>$`\n\r]/`) that inspects the `args` parameter. If any forbidden shell metacharacter is detected, it returns an explicit error message instead of executing the command, effectively neutralizing the attack vector while preserving normal argument functionality.

---
*PR created automatically by Jules for task [16420529453983174616](https://jules.google.com/task/16420529453983174616) started by @giauphan*