### PR TITLE
🛡️ Sentinel: [HIGH] Fix missing authorization check in project_context tool

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -26,3 +26,8 @@
 **Vulnerability:** MCP tools allowed unbounded string lengths in Zod schemas (`z.string()`).
 **Learning:** Missing input length validation allows attackers to submit extremely large strings causing excessive memory usage and parsing overhead (CWE-400), leading to Denial of Service (DoS).
 **Prevention:** Always explicitly set maximum string lengths (e.g., `.max(255)`) on all `z.string()` schemas.
+
+## 2024-05-18 - Missing Authorization Check in Tool
+**Vulnerability:** The `project_context` tool in `src/presentation/mcpServer.ts` was missing an authorization validation check (`isPathInAuthorizedProjects`) before reading configuration files, reading the README, and fetching git status from the provided project directory.
+**Learning:** Even tools that only read data (like `project_context`) and seem harmless can still be exploited if they take a `project` path as an argument and construct arbitrary paths without validating against authorized workspace boundaries. An attacker might provide an absolute path like `/etc` as the project directory to read the file structure or specific configuration files.
+**Prevention:** Always use the `isPathInAuthorizedProjects` check in any tool that accepts a user-provided project directory or path before proceeding with any file system operations.

--- a/src/presentation/mcpServer.ts
+++ b/src/presentation/mcpServer.ts
@@ -1882,6 +1882,14 @@ export function registerTools(server: McpServer) {
       if (!loaded) return { content: [{ type: "text" as const, text: "No analysis found. Run 'analyze' first." }] };
 
       const projectDir = loaded.projectDir;
+
+      // 🛡️ Sentinel Security Validation
+      // Ensure the project directory is an authorized workspace to prevent path traversal
+      const authorizedProjects = await discoverProjectsAsync(auth.uid);
+      if (!isPathInAuthorizedProjects(projectDir, authorizedProjects)) {
+        return { content: [{ type: "text" as const, text: JSON.stringify({ error: "Unauthorized project directory" }) }] };
+      }
+
       const ctx: any = { name: loaded.projectName, path: projectDir };
 
       // package.json


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `project_context` tool in `src/presentation/mcpServer.ts` lacked an authorization validation check (`isPathInAuthorizedProjects`) before conducting operations like reading configuration files, parsing README, and fetching git status.
🎯 Impact: This could be exploited by an attacker to pass an arbitrary path outside of the user's workspace context to read arbitrary project info or configuration files.
🔧 Fix: Used `isPathInAuthorizedProjects` function with `discoverProjectsAsync` for authorization boundary checking. 
✅ Verification: Tested against existing logic via test suite and `npm run build`.

---
*PR created automatically by Jules for task [8619479502725918172](https://jules.google.com/task/8619479502725918172) started by @giauphan*