### PR TITLE
⚡ Bolt: [performance improvement] Optimize AI insights graph traversal

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -45,3 +45,6 @@
 ## 2026-07-26 - [Performance improvement] Array.find inside Array.map
 **Learning:** Found an O(L*N) bottleneck in `mcpServer.ts` (exporting artifact summary) and `e2e.test.ts` where `Array.prototype.find()` was called inside `Array.prototype.map()` for every graph link to find its source and target nodes. This is extremely slow for large AST graphs.
 **Action:** Always precompute a lookup Map (e.g., `Map<string, string>`) in O(N) time before the loop, and use `.get()` to look up elements in O(1) time. Also avoid chained `.filter().map().slice()` by combining them into a single early-exit `for` loop.
+## 2026-07-26 - [Performance improvement] Optimized O(N*E) generateAIInsights
+**Learning:** Filtering a links array for every node using `graph.links.filter` creates an O(N*E) bottleneck when checking relationships (like finding modules with many functions).
+**Action:** When filtering or counting relationships between nodes, avoid nesting a links filter inside a nodes loop. Instead, do a single O(E) pass over the links array to precompute the required counts in a Map, enabling O(1) lookups during the subsequent O(N) nodes loop.

--- a/src/analyzer/parser.ts
+++ b/src/analyzer/parser.ts
@@ -1217,10 +1217,17 @@ export class CodeAnalyzer {
     // Mock AI Insights generation based on simple heuristics
     
     // 1. Large files / God objects
+    // ⚡ Bolt Optimization: Replace O(N*E) nested array filter with O(E) precomputed Map and O(1) lookups
+    const moduleFunctionCounts = new Map<string, number>();
+    for (const l of graph.links) {
+      if (l.type === 'contains' && l.target.startsWith('function')) {
+        moduleFunctionCounts.set(l.source, (moduleFunctionCounts.get(l.source) || 0) + 1);
+      }
+    }
+
     const modulesWithManyFunctions = Array.from(this.nodes.values()).filter(n => {
       if (n.type !== 'module') return false;
-      const functionCount = graph.links.filter(l => l.source === n.id && l.type === 'contains' && l.target.startsWith('function')).length;
-      return functionCount > 10; // threshold
+      return (moduleFunctionCounts.get(n.id) || 0) > 10; // threshold
     });
 
     if (modulesWithManyFunctions.length > 0) {


### PR DESCRIPTION
💡 What: The nested `graph.links.filter` used inside `nodes.filter` during the `generateAIInsights` method's "God Object" detection was replaced with an O(E) pass to build a `moduleFunctionCounts` Map that provides O(1) lookups in the subsequent O(N) loop.
🎯 Why: An O(N*E) operation where N is nodes and E is links introduces significant performance bottlenecks as the size of the CodeAtlas graph scales up.
📊 Impact: Asymptotically reduces time complexity for God Object checking from quadratic O(N*E) to linear O(N+E), directly reducing CPU time and blocking I/O overhead on massive trees.
🔬 Measurement: Verify by executing test suite or benchmarking graph generations of large project repositories with and without the change.

---
*PR created automatically by Jules for task [16327700609162766784](https://jules.google.com/task/16327700609162766784) started by @giauphan*