### PR TITLE
⚡ Bolt: [performance improvement] O(N) array finds and loop invariants

### DIFF
--- a/src/presentation/mcpServer.ts
+++ b/src/presentation/mcpServer.ts
@@ -1079,7 +1079,7 @@ export function registerTools(server: McpServer) {
         totalConnected: visited.size,
         depth: maxDepth,
         files: filesArray.filter((f) => f.filePath !== "external").slice(0, 30),
-        externalDeps: filesArray.find((f) => f.filePath === "external")?.entities.map((e) => e.name) || [],
+        externalDeps: byFile.get("external")?.map((e) => e.name) || [],
         relationships: traceLinks.slice(0, 50).map((l) => ({
           from: nodeMap.get(l.source)?.label || l.source,
           to: nodeMap.get(l.target)?.label || l.target,

--- a/src/securityScanner.ts
+++ b/src/securityScanner.ts
@@ -96,7 +96,6 @@ export class SecurityScanner {
     try {
       const criticalFindings = findings.filter(f => f.severity === "CRITICAL" || f.severity === "HIGH").slice(0, 5);
       const codeContext = criticalFindings.map(f => {
-        const node = analysis.graph.nodes.find(n => n.filePath === f.filePath);
         return "[" + f.severity + "] " + f.type + ": " + f.message + " (" + f.filePath + ":" + f.line + ")";
       }).join("\n");
 

--- a/src/services/projectService.ts
+++ b/src/services/projectService.ts
@@ -753,8 +753,9 @@ export function loadAnalysis(projectDir?: string, force = false): { analysis: An
       console.warn(`[Auto-Scan] 🛡️ Ignored IDE system/extensions directory from workspace indexing: ${absPath}`);
       return null;
     }
+    const lowerProjectDir = projectDir.trim().toLowerCase();
     let match = projects.find(
-      (p) => p.dir === absPath || p.name.toLowerCase() === projectDir.trim().toLowerCase()
+      (p) => p.dir === absPath || p.name.toLowerCase() === lowerProjectDir
     );
     if (match) {
       target = match;
@@ -925,8 +926,9 @@ export async function loadAnalysisAsync(
       console.warn(`[Auto-Scan] 🛡️ Ignored IDE system/extensions directory from workspace indexing: ${absPath}`);
       return null;
     }
+    const lowerProjectDir = projectDir.trim().toLowerCase();
     let match = projects.find(
-      (p) => p.dir === absPath || p.name.toLowerCase() === projectDir.trim().toLowerCase()
+      (p) => p.dir === absPath || p.name.toLowerCase() === lowerProjectDir
     );
     if (match) {
       target = match;


### PR DESCRIPTION
💡 What: Three small, targeted performance improvements:
1. Replaced an O(N) `Array.find` operation in `mcpServer.ts` (`export_team_artifact` tool execution) with an O(1) `Map.get()` lookup.
2. Extracted `projectDir.trim().toLowerCase()` out of a `find()` loop in `projectService.ts` `loadAnalysis` methods.
3. Removed an unused `node` variable definition from `aiScan` in `securityScanner.ts` which avoided a costly O(N) lookup per iteration inside a `.map` execution.

🎯 Why: To reduce redundant string allocations and improve algorithmic efficiency. Specifically, `Array.find` inside `.map` creates an O(N*M) scenario that can easily bog down when graph models scale, and re-computing `.toLowerCase()` strings creates GC pressure in loops. 

📊 Impact: Reduces computational load during feature trace graph generation, accelerates project discovery/matching when loading analysis, and avoids O(N*M) overhead completely in security scan preparation. 

🔬 Measurement: Run `npm run test` to verify correctness is preserved. These types of optimizations lower baseline overhead when dealing with 10k+ AST nodes.

---
*PR created automatically by Jules for task [13307021691726705648](https://jules.google.com/task/13307021691726705648) started by @giauphan*