### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix String Replacement Injection vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -47,3 +47,7 @@
 **Vulnerability:** The `checkAuth` function used for authorization fell back to granting full privileges via a mock local user if no authentication context was found and `CODEATLAS_MULTI_TENANT` was not explicitly enabled.
 **Learning:** Returning mock authentication credentials as a default fallback allows attackers to easily bypass authentication simply by not providing any credentials.
 **Prevention:** Never use mock objects or fallback roles when authentication fails or is missing. Always throw an explicit unauthorized error.
+## 2025-02-23 - Prevent String Replacement Injection in String.prototype.replace()
+**Vulnerability:** The configuration string replacement in `mcpServer.ts` passed dynamic content (`mcpEntry`, which contains an environment variable) as a string to `String.prototype.replace()`.
+**Learning:** If the dynamic content includes special replacement patterns (like `$&`, `$1`, or `$'`), the `replace` function interpolates the matches instead of treating it as literal text, which can cause data corruption or structural injection in generated configuration files.
+**Prevention:** Always use a replacer function (e.g., `() => replacement`) instead of a string argument when using `String.prototype.replace()` with dynamic or external input.

--- a/src/presentation/mcpServer.ts
+++ b/src/presentation/mcpServer.ts
@@ -2164,7 +2164,7 @@ export function registerTools(server: McpServer) {
             if (cfg.includes("codeatlas:")) {
               results.push({ client: "hermes", action: "mcp_config", status: "already_configured" });
             } else if (cfg.includes("mcp_servers:")) {
-              cfg = cfg.replace("mcp_servers:", "mcp_servers:\n" + mcpEntry);
+              cfg = cfg.replace("mcp_servers:", () => "mcp_servers:\n" + mcpEntry);
               fs.writeFileSync(hermesCfg, cfg);
               results.push({ client: "hermes", action: "mcp_config", status: "updated" });
             } else {


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** String Replacement Injection. When modifying configuration files (like `mcp_servers` in Hermes), `String.prototype.replace()` was used with a string argument containing dynamic user/environment input (`CODEATLAS_API_KEY`). If the input contains special characters like `$&`, the `replace` function misinterprets them as regex replacement patterns instead of literal text, leading to data corruption and potential structural configuration injection.
🎯 **Impact:** An attacker could craft an API key or environment variable containing `$&` to inject the matched string or corrupt the generated configuration files (e.g. `~/.hermes/config.yaml`), breaking the system or potentially injecting unintended directives.
🔧 **Fix:** Changed the replacement string argument to a replacer function (`() => "mcp_servers:\n" + mcpEntry`) in `src/presentation/mcpServer.ts`. JavaScript treats the return value of a replacer function as a literal string, completely neutralizing any interpolation patterns.
✅ **Verification:** Verified by reviewing the codebase, ensuring `String.prototype.replace()` uses a replacer function, and running the full test suite (`npm run build && npm run test`) which passes without regressions.

---
*PR created automatically by Jules for task [7583699303827308799](https://jules.google.com/task/7583699303827308799) started by @giauphan*