### PR TITLE
⚡ Bolt: Optimize Jaccard similarity calculations in tight loops

### DIFF
--- a/src/presentation/mcpServer.ts
+++ b/src/presentation/mcpServer.ts
@@ -2683,11 +2683,16 @@ def register(ctx):
           // Quick check: skip if files too different in size
           if (Math.abs(a.tokens.size - b.tokens.size) > Math.max(a.tokens.size, b.tokens.size) * 0.7) continue;
 
-          const intersection = new Set([...a.tokens].filter(t => b.tokens.has(t)));
-          const union = new Set([...a.tokens, ...b.tokens]);
-          if (union.size === 0) continue;
+          let intersectionSize = 0;
+          for (const t of a.tokens) {
+            if (b.tokens.has(t)) {
+              intersectionSize++;
+            }
+          }
+          const unionSize = a.tokens.size + b.tokens.size - intersectionSize;
+          if (unionSize === 0) continue;
 
-          const sim = intersection.size / union.size;
+          const sim = intersectionSize / unionSize;
           if (sim >= thresh) {
             const aFile = path.relative(loaded.projectDir, a.node.filePath!);
             const bFile = path.relative(loaded.projectDir, b.node.filePath!);
@@ -2695,8 +2700,8 @@ def register(ctx):
               a: { name: a.node.label, file: aFile, line: a.node.line || 0, type: a.node.type },
               b: { name: b.node.label, file: bFile, line: b.node.line || 0, type: b.node.type },
               similarity: Math.round(sim * 100) / 100,
-              sharedTokens: intersection.size,
-              totalTokens: union.size,
+              sharedTokens: intersectionSize,
+              totalTokens: unionSize,
             });
           }
 

--- a/src/presentation/mcpServer.ts
+++ b/src/presentation/mcpServer.ts
@@ -4,6 +4,7 @@ import * as fs from "fs";
 import * as path from "path";
 import * as os from "os";
 import { getHomePath, getHermesConfigPath, getHermesPluginDir, getClaudeConfigPath } from "../utils/pathUtils.js";
+import { jaccardSimilarity } from "../utils/mathUtils.js";
 import { checkAuth, logActivity } from "../services/authService.js";
 import {
   discoverProjectsAsync,
@@ -2683,23 +2684,16 @@ def register(ctx):
           // Quick check: skip if files too different in size
           if (Math.abs(a.tokens.size - b.tokens.size) > Math.max(a.tokens.size, b.tokens.size) * 0.7) continue;
 
-          let intersectionSize = 0;
-          for (const t of a.tokens) {
-            if (b.tokens.has(t)) {
-              intersectionSize++;
-            }
-          }
-          const unionSize = a.tokens.size + b.tokens.size - intersectionSize;
+          const { similarity, intersectionSize, unionSize } = jaccardSimilarity(a.tokens, b.tokens);
           if (unionSize === 0) continue;
 
-          const sim = intersectionSize / unionSize;
-          if (sim >= thresh) {
+          if (similarity >= thresh) {
             const aFile = path.relative(loaded.projectDir, a.node.filePath!);
             const bFile = path.relative(loaded.projectDir, b.node.filePath!);
             pairs.push({
               a: { name: a.node.label, file: aFile, line: a.node.line || 0, type: a.node.type },
               b: { name: b.node.label, file: bFile, line: b.node.line || 0, type: b.node.type },
-              similarity: Math.round(sim * 100) / 100,
+              similarity: Math.round(similarity * 100) / 100,
               sharedTokens: intersectionSize,
               totalTokens: unionSize,
             });

--- a/src/services/e2e.test.ts
+++ b/src/services/e2e.test.ts
@@ -208,10 +208,15 @@ export class HelperService {
       const tokensA = tokenize(contentA);
       const tokensB = tokenize(contentB);
 
-      const intersection = new Set([...tokensA].filter(t => tokensB.has(t)));
-      const union = new Set([...tokensA, ...tokensB]);
+      let intersectionSize = 0;
+      for (const t of tokensA) {
+        if (tokensB.has(t)) {
+          intersectionSize++;
+        }
+      }
+      const unionSize = tokensA.size + tokensB.size - intersectionSize;
 
-      const similarity = intersection.size / union.size;
+      const similarity = intersectionSize / unionSize;
       // These two files are very similar (same structure, different names)
       assert.ok(similarity >= 0.5, `Similarity should be >= 0.5, got ${similarity}`);
     });
@@ -227,10 +232,15 @@ export class HelperService {
 
       const tokensA = tokenize("abc def ghi xyz");
       const tokensB = tokenize("xxx yyy zzz");
-      const intersection = new Set([...tokensA].filter(t => tokensB.has(t)));
-      const union = new Set([...tokensA, ...tokensB]);
-      assert.strictEqual(intersection.size, 0);
-      assert.strictEqual(union.size, 7);
+      let intersectionSize = 0;
+      for (const t of tokensA) {
+        if (tokensB.has(t)) {
+          intersectionSize++;
+        }
+      }
+      const unionSize = tokensA.size + tokensB.size - intersectionSize;
+      assert.strictEqual(intersectionSize, 0);
+      assert.strictEqual(unionSize, 7);
     });
   });
 

--- a/src/services/e2e.test.ts
+++ b/src/services/e2e.test.ts
@@ -3,6 +3,7 @@ import * as assert from "node:assert";
 import * as fs from "fs";
 import * as path from "path";
 import * as os from "os";
+import { jaccardSimilarity } from "../utils/mathUtils.js";
 
 const TMP_DIR = path.join(os.tmpdir(), "codeatlas-e2e-" + Date.now());
 const PROJECT_DIR = path.join(TMP_DIR, "test-project");
@@ -208,15 +209,7 @@ export class HelperService {
       const tokensA = tokenize(contentA);
       const tokensB = tokenize(contentB);
 
-      let intersectionSize = 0;
-      for (const t of tokensA) {
-        if (tokensB.has(t)) {
-          intersectionSize++;
-        }
-      }
-      const unionSize = tokensA.size + tokensB.size - intersectionSize;
-
-      const similarity = intersectionSize / unionSize;
+      const { similarity } = jaccardSimilarity(tokensA, tokensB);
       // These two files are very similar (same structure, different names)
       assert.ok(similarity >= 0.5, `Similarity should be >= 0.5, got ${similarity}`);
     });
@@ -232,13 +225,7 @@ export class HelperService {
 
       const tokensA = tokenize("abc def ghi xyz");
       const tokensB = tokenize("xxx yyy zzz");
-      let intersectionSize = 0;
-      for (const t of tokensA) {
-        if (tokensB.has(t)) {
-          intersectionSize++;
-        }
-      }
-      const unionSize = tokensA.size + tokensB.size - intersectionSize;
+      const { intersectionSize, unionSize } = jaccardSimilarity(tokensA, tokensB);
       assert.strictEqual(intersectionSize, 0);
       assert.strictEqual(unionSize, 7);
     });

--- a/src/utils/mathUtils.ts
+++ b/src/utils/mathUtils.ts
@@ -1,4 +1,8 @@
 export function jaccardSimilarity(a: Set<string>, b: Set<string>): { similarity: number, intersectionSize: number, unionSize: number } {
+  if (a.size > b.size) {
+    return jaccardSimilarity(b, a);
+  }
+
   let intersectionSize = 0;
   for (const t of a) {
     if (b.has(t)) {

--- a/src/utils/mathUtils.ts
+++ b/src/utils/mathUtils.ts
@@ -1,0 +1,12 @@
+export function jaccardSimilarity(a: Set<string>, b: Set<string>): { similarity: number, intersectionSize: number, unionSize: number } {
+  let intersectionSize = 0;
+  for (const t of a) {
+    if (b.has(t)) {
+      intersectionSize++;
+    }
+  }
+  const unionSize = a.size + b.size - intersectionSize;
+  const similarity = unionSize === 0 ? 0 : intersectionSize / unionSize;
+
+  return { similarity, intersectionSize, unionSize };
+}


### PR DESCRIPTION
💡 What: Replaced intermediate Array and Set allocations in Jaccard similarity calculation loops (in both mcpServer.ts and e2e.test.ts) with mathematical iteration.
🎯 Why: Creating new Arrays and Sets via spread operator and `.filter` inside O(N^2) tight loops causes severe GC pressure, memory spikes, and significant CPU overhead.
📊 Impact: Reduces memory allocation to O(1) space inside the comparison loop, drastically improving performance for similarity detection across large codebases.
🔬 Measurement: Run the test suite (`npm test`) which explicitly calculates Jaccard similarities in `e2e.test.ts` and ensure correct values and fast execution.

---
*PR created automatically by Jules for task [10711763086325794834](https://jules.google.com/task/10711763086325794834) started by @giauphan*