### PR TITLE
⚡ Bolt: [performance improvement] Precompute links map to fix O(N*L) bottleneck

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -58,3 +58,7 @@
 ## 2025-07-29 - [Performance improvement] Optimized O(E) double link traversal
 **Learning:** Traversing the same `links` array multiple times (e.g. using `links.forEach()` to count outgoing connections, then `links.forEach()` again to count incoming connections) wastes execution time.
 **Action:** When calculating multiple distinct graph metrics from links, combine them into a single O(E) loop that populates multiple Maps simultaneously.
+
+## 2026-07-26 - [Performance improvement] Optimized O(N*L) link filtering inside node mapping
+**Learning:** Checking for node connections by using `nodes.map` and inside it `links.filter` is an O(N*L) operation which leads to a severe performance bottleneck for large graphs. Precomputing Maps for incoming/outgoing links by iterating over the `links` array once takes O(L) time and makes the lookup O(1), bringing the total time complexity to O(N+L).
+**Action:** When mapping relationships for a subset of nodes, avoid nesting a links `filter` inside a nodes `map`. Instead, do a single O(L) pass over the links array to precompute a `Map`, enabling O(1) lookups during the subsequent O(N) nodes mapping.

--- a/src/presentation/mcpServer.ts
+++ b/src/presentation/mcpServer.ts
@@ -328,24 +328,37 @@ export function registerTools(server: McpServer) {
       const links = loaded.analysis.graph.links;
       const nodeMap = createNodeLabelMap(loaded.analysis.graph.nodes);
 
+      // ⚡ Bolt Optimization: Precompute links for matched nodes to avoid O(N*L) filtering inside map
+      const topMatches = matches.slice(0, 50);
+      const matchIds = new Set(topMatches.map((n) => n.id));
+
+      const incomingLinksMap = new Map<string, Array<{ from: string, type: string }>>();
+      const outgoingLinksMap = new Map<string, Array<{ to: string, type: string }>>();
+
+      for (const l of links) {
+        if (matchIds.has(l.target)) {
+          let arr = incomingLinksMap.get(l.target);
+          if (!arr) { arr = []; incomingLinksMap.set(l.target, arr); }
+          arr.push({ from: nodeMap.get(l.source) || l.source, type: l.type });
+        }
+        if (matchIds.has(l.source)) {
+          let arr = outgoingLinksMap.get(l.source);
+          if (!arr) { arr = []; outgoingLinksMap.set(l.source, arr); }
+          arr.push({ to: nodeMap.get(l.target) || l.target, type: l.type });
+        }
+      }
+
       const result = {
         query,
         matchCount: matches.length,
-        results: matches.slice(0, 50).map((n) => {
-          const incomingLinks = links
-            .filter((l) => l.target === n.id)
-            .map((l) => ({ from: nodeMap.get(l.source) || l.source, type: l.type }));
-          const outgoingLinks = links
-            .filter((l) => l.source === n.id)
-            .map((l) => ({ to: nodeMap.get(l.target) || l.target, type: l.type }));
-
+        results: topMatches.map((n) => {
           return {
             name: n.label,
             type: n.type,
             filePath: n.filePath ? (path.isAbsolute(n.filePath) ? n.filePath : path.resolve(loaded.projectDir, n.filePath)) : null,
             line: n.line || null,
-            incomingRelationships: incomingLinks,
-            outgoingRelationships: outgoingLinks,
+            incomingRelationships: incomingLinksMap.get(n.id) || [],
+            outgoingRelationships: outgoingLinksMap.get(n.id) || [],
           };
         }),
       };
@@ -389,6 +402,18 @@ export function registerTools(server: McpServer) {
 
       let filesEntries = Array.from(byFile.entries());
 
+      // ⚡ Bolt Optimization: Precompute dependencies for matched nodes to avoid O(N*L) filtering inside map
+      const matchIds = new Set(matches.map((n) => n.id));
+      const dependenciesMap = new Map<string, Array<{ to: string, type: string }>>();
+
+      for (const l of links) {
+        if (matchIds.has(l.source)) {
+          let arr = dependenciesMap.get(l.source);
+          if (!arr) { arr = []; dependenciesMap.set(l.source, arr); }
+          arr.push({ to: nodeMap.get(l.target) || l.target, type: l.type });
+        }
+      }
+
       const result = {
         query: filePath,
         filesFound: byFile.size,
@@ -400,9 +425,7 @@ export function registerTools(server: McpServer) {
             name: e.label,
             type: e.type,
             line: e.line || null,
-            dependencies: links
-              .filter((l) => l.source === e.id)
-              .map((l) => ({ to: nodeMap.get(l.target) || l.target, type: l.type })),
+            dependencies: dependenciesMap.get(e.id) || [],
           })),
         })),
       };


### PR DESCRIPTION
💡 **What:**
Optimized `search_nodes` and `get_file_entities` tools in `src/presentation/mcpServer.ts` by replacing O(N*L) mapping operations with an O(L) pass and precomputed Map. 

🎯 **Why:**
Using `.map` on matched nodes and then filtering a large graph `links` array for each node introduces a severe `O(N * L)` performance penalty for projects with thousands of nodes and links. Precomputing a Map makes lookups `O(1)`, resulting in `O(N + L)` total time complexity.

📊 **Impact:**
Massive performance improvement in large AST graphs for search functionality and file resolution processing by virtually eliminating heavy array iterations on the main loop. 

🔬 **Measurement:**
Automated testing passes via `npm run build && npm run test`. Code logic strictly mimics original behavior with an empty array `[]` returned if `Map.get(id)` returns undefined.

---
*PR created automatically by Jules for task [17478760402326746233](https://jules.google.com/task/17478760402326746233) started by @giauphan*