### PR TITLE
🛡️ Sentinel: [HIGH] Fix indirect command injection and path traversal in run_script tool

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -51,3 +51,7 @@
 **Vulnerability:** The configuration string replacement in `mcpServer.ts` passed dynamic content (`mcpEntry`, which contains an environment variable) as a string to `String.prototype.replace()`.
 **Learning:** If the dynamic content includes special replacement patterns (like `$&`, `$1`, or `$'`), the `replace` function interpolates the matches instead of treating it as literal text, which can cause data corruption or structural injection in generated configuration files.
 **Prevention:** Always use a replacer function (e.g., `() => replacement`) instead of a string argument when using `String.prototype.replace()` with dynamic or external input.
+## 2024-08-02 - Indirect Command Injection via Unsanitized `cwd` in `spawnSync`
+**Vulnerability:** Indirect command injection vulnerability in `run_script` tool where an unvalidated `projectDir` was passed as `cwd` to `child_process.spawnSync` despite `shell: false` being used.
+**Learning:** Target binaries like `npm` or `sh` may internally spawn their own shells. If the `cwd` parameter is attacker-controlled and contains shell metacharacters, it can become an indirect command injection vector even when `spawnSync` is explicitly configured with `shell: false`.
+**Prevention:** Always sanitize user-influenced directory paths (e.g., using `SHELL_METACHAR_RE` regex) before passing them as the `cwd` option in child process executions.

--- a/src/presentation/mcpServer.ts
+++ b/src/presentation/mcpServer.ts
@@ -1991,15 +1991,28 @@ export function registerTools(server: McpServer) {
 
       // 🛡️ Sentinel Security Validation
       // Use spawnSync without a shell to prevent command injection entirely
-      const projectDir = loaded.projectDir;
 
-      // Ensure the project directory is an authorized workspace to prevent path traversal
+      // Resolve the project directory immediately to ensure path traversal tokens (like `../`)
+      // are fully expanded before validation occurs.
+      let resolvedDir: string;
+      try {
+        resolvedDir = fs.realpathSync(loaded.projectDir);
+      } catch {
+        return { content: [{ type: "text" as const, text: JSON.stringify({ error: "Invalid project directory" }) }] };
+      }
+
+      // Ensure the resolved project directory is an authorized workspace to prevent path traversal
       const authorizedProjects = await discoverProjectsAsync(auth.uid);
-      if (!isPathInAuthorizedProjects(projectDir, authorizedProjects)) {
+      if (!isPathInAuthorizedProjects(resolvedDir, authorizedProjects)) {
         return { content: [{ type: "text" as const, text: JSON.stringify({ error: "Unauthorized project directory" }) }] };
       }
 
-      const pkgPath = path.join(projectDir, "package.json");
+      // Security: Block shell metacharacters in directory path to prevent indirect command injection via cwd
+      if (SHELL_METACHAR_RE.test(resolvedDir)) {
+        return { content: [{ type: "text" as const, text: JSON.stringify({ error: "Security Error: Directory path contains forbidden shell metacharacters" }) }] };
+      }
+
+      const pkgPath = path.join(resolvedDir, "package.json");
       if (fs.existsSync(pkgPath)) {
         try {
           const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf-8"));
@@ -2043,7 +2056,7 @@ export function registerTools(server: McpServer) {
           timeout: maxTime * 1000,
           shell: false, // Security: explicit shell false
           maxBuffer: 1024 * 1024,
-          cwd: projectDir
+          cwd: resolvedDir
         });
 
         const dur = ((Date.now() - startTime) / 1000).toFixed(1);


### PR DESCRIPTION
🚨 **Severity**: HIGH
💡 **Vulnerability**: Indirect command injection via `cwd` containing shell metacharacters during `spawnSync` and path traversal risks via unresolved relative bounds in `run_script`.
🎯 **Impact**: An attacker who can influence the project path could leverage shell metacharacters in `cwd` to achieve command injection when `npm` is launched, or use `../` to access directories outside the intended workspace boundary before being passed to validation.
🔧 **Fix**: Enforced strict resolution of `loaded.projectDir` via `fs.realpathSync` prior to `isPathInAuthorizedProjects` to align with strict path bounds, and introduced `SHELL_METACHAR_RE` check to fully sanitize `cwd` before `spawnSync`.
✅ **Verification**: Tests run cleanly and manual verification of the patch ensures that unhandled paths are now rejected securely. Documented the learning in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [2821400037443459777](https://jules.google.com/task/2821400037443459777) started by @giauphan*