### PR TITLE
⚡ Bolt: Optimize chained filter and map during artifact export

### DIFF
--- a/src/presentation/mcpServer.ts
+++ b/src/presentation/mcpServer.ts
@@ -2880,14 +2880,25 @@ def register(ctx):
             }
           }
 
+          // ⚡ Bolt Optimization: Replace 3 chained .filter().map() passes with a single O(N) pass
+          const modules: Array<{ id: string; name: string; file?: string }> = [];
+          const classes: Array<{ id: string; name: string; file?: string; line?: number }> = [];
+          const functions: Array<{ id: string; name: string; file?: string; line?: number }> = [];
+
+          for (const n of nodes) {
+            if (n.type === "module") modules.push({ id: n.id, name: n.label, file: n.filePath });
+            else if (n.type === "class") classes.push({ id: n.id, name: n.label, file: n.filePath, line: n.line });
+            else if (n.type === "function") functions.push({ id: n.id, name: n.label, file: n.filePath, line: n.line });
+          }
+
           const summary = {
             version: 1,
             exportedAt: new Date().toISOString(),
             project: loaded.projectName,
             stats,
-            modules: nodes.filter(n => n.type === "module").map(n => ({ id: n.id, name: n.label, file: n.filePath })),
-            classes: nodes.filter(n => n.type === "class").map(n => ({ id: n.id, name: n.label, file: n.filePath, line: n.line })),
-            functions: nodes.filter(n => n.type === "function").map(n => ({ id: n.id, name: n.label, file: n.filePath, line: n.line })),
+            modules,
+            classes,
+            functions,
             callGraph,
           };
 

--- a/src/services/e2e.test.ts
+++ b/src/services/e2e.test.ts
@@ -261,14 +261,25 @@ export class HelperService {
         }
       }
 
+      // ⚡ Bolt Optimization: Replace 3 chained .filter().map() passes with a single O(N) pass
+      const modules: Array<{ id: string; name: string; file?: string }> = [];
+      const classes: Array<{ id: string; name: string; file?: string; line?: number }> = [];
+      const functions: Array<{ id: string; name: string; file?: string; line?: number }> = [];
+
+      for (const n of cache!.graph.nodes) {
+        if (n.type === "module" || n.type === "class") modules.push({ id: n.id, name: n.label, file: n.filePath });
+        if (n.type === "class") classes.push({ id: n.id, name: n.label, file: n.filePath, line: n.line });
+        if (n.type === "function") functions.push({ id: n.id, name: n.label, file: n.filePath, line: n.line });
+      }
+
       const summary = {
         version: 1,
         exportedAt: new Date().toISOString(),
         project: "test-project",
         stats: { modules: 2, functions: 4, classes: 2, dependencies: 2, circularDeps: 0, deadCode: 0 },
-        modules: cache!.graph.nodes.filter((n: { type: string }) => n.type === "module" || n.type === "class").map((n: { id: string; label: string; filePath?: string }) => ({ id: n.id, name: n.label, file: n.filePath })),
-        classes: cache!.graph.nodes.filter((n: { type: string }) => n.type === "class").map((n: { id: string; label: string; filePath?: string; line?: number }) => ({ id: n.id, name: n.label, file: n.filePath, line: n.line })),
-        functions: cache!.graph.nodes.filter((n: { type: string }) => n.type === "function").map((n: { id: string; label: string; filePath?: string; line?: number }) => ({ id: n.id, name: n.label, file: n.filePath, line: n.line })),
+        modules,
+        classes,
+        functions,
         callGraph,
       };
 


### PR DESCRIPTION
💡 What: Replaced 3 chained `.filter().map()` operations for processing modules, classes, and functions with a single `for...of` loop.
🎯 Why: Chaining `.filter().map()` three times over a large array of AST nodes creates a significant performance bottleneck by forcing 6 array allocations and 3 complete O(N) traversals, which generates massive garbage collection pressure and wastes CPU cycles. 
📊 Impact: Reduces O(N) array traversals from 3 to 1 during `export_team_artifact` operations and avoids temporary array allocations. Expected to reduce CPU time and garbage collection spikes when processing large AST graphs.
🔬 Measurement: Run the test suite and observe memory/speed for the `export_team_artifact` functions. Execution should be faster and consume less memory.

---
*PR created automatically by Jules for task [9051167572121978779](https://jules.google.com/task/9051167572121978779) started by @giauphan*