### PR TITLE
⚡ [performance improvement] Optimize AI insight generation in parser

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -87,3 +87,7 @@
 ## 2024-05-18 - Optimize sync_skills_inventory I/O
 **Learning:** Checking `fs.existsSync` inside tight loops before an operation (like `fs.readdirSync` or `fs.readFileSync`) creates redundant system calls and introduces a minor TOCTOU race condition. Also, iterating over `fs.readdirSync` requires explicit `.statSync` or `.isDirectory()` to filter entries, but using `{ withFileTypes: true }` avoids additional file stat lookups.
 **Action:** Used the EAFP (Easier to Ask for Forgiveness than Permission) pattern by wrapping `fs.readFileSync` in a `try/catch` and removing `fs.existsSync`. Updated `fs.readdirSync` to use `{ withFileTypes: true }` to filter out non-directories without needing extra stat calls.
+
+## 2026-08-07 - Avoid Unrelated Syntax/Compilation Errors During Refactors
+**Learning:** In codebases with existing compilation errors in other files, it's critical to isolate changes cleanly and not accidentally 'adopt' or introduce new errors when attempting to resolve unrelated build failures. Modifying a file that has pre-existing errors outside the scope of the target optimization can lead to rejected code reviews due to unintended side-effects.
+**Action:** When a file outside the intended scope shows compilation errors, stash or revert local changes to verify if the error exists on `main`. Do not blindly delete or "fix" code in unrelated files without full context. Focus strictly on the files relevant to the planned optimization.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -87,7 +87,3 @@
 ## 2024-05-18 - Optimize sync_skills_inventory I/O
 **Learning:** Checking `fs.existsSync` inside tight loops before an operation (like `fs.readdirSync` or `fs.readFileSync`) creates redundant system calls and introduces a minor TOCTOU race condition. Also, iterating over `fs.readdirSync` requires explicit `.statSync` or `.isDirectory()` to filter entries, but using `{ withFileTypes: true }` avoids additional file stat lookups.
 **Action:** Used the EAFP (Easier to Ask for Forgiveness than Permission) pattern by wrapping `fs.readFileSync` in a `try/catch` and removing `fs.existsSync`. Updated `fs.readdirSync` to use `{ withFileTypes: true }` to filter out non-directories without needing extra stat calls.
-
-## 2026-08-07 - Avoid Unrelated Syntax/Compilation Errors During Refactors
-**Learning:** In codebases with existing compilation errors in other files, it's critical to isolate changes cleanly and not accidentally 'adopt' or introduce new errors when attempting to resolve unrelated build failures. Modifying a file that has pre-existing errors outside the scope of the target optimization can lead to rejected code reviews due to unintended side-effects.
-**Action:** When a file outside the intended scope shows compilation errors, stash or revert local changes to verify if the error exists on `main`. Do not blindly delete or "fix" code in unrelated files without full context. Focus strictly on the files relevant to the planned optimization.

--- a/src/analyzer/parser.ts
+++ b/src/analyzer/parser.ts
@@ -1214,14 +1214,12 @@ export class CodeAnalyzer {
     // Mock AI Insights generation based on simple heuristics
     
     // 1. Large files / God objects
-
     const moduleFunctionCounts = new Map<string, number>();
     for (const l of graph.links) {
       if (l.type === 'contains' && l.target.startsWith('function')) {
         moduleFunctionCounts.set(l.source, (moduleFunctionCounts.get(l.source) || 0) + 1);
       }
     }
-
 
     const affectedModules: string[] = [];
     for (const node of this.nodes.values()) {
@@ -1248,7 +1246,6 @@ export class CodeAnalyzer {
         moduleDependencies.set(l.source, (moduleDependencies.get(l.source) || 0) + 1);
       }
     }
-
 
     const highlyCoupled: string[] = [];
     for (const [id, count] of moduleDependencies.entries()) {

--- a/src/analyzer/parser.ts
+++ b/src/analyzer/parser.ts
@@ -1222,31 +1222,39 @@ export class CodeAnalyzer {
       }
     }
 
-    const modulesWithManyFunctions = Array.from(this.nodes.values()).filter(n => {
-      if (n.type !== 'module') return false;
-      return (moduleFunctionCounts.get(n.id) || 0) > 10; // threshold
-    });
+    // ⚡ Bolt Optimization: Single O(N) pass, eliminating chained Array.from().filter().map() allocations
+    const affectedModules: string[] = [];
+    for (const node of this.nodes.values()) {
+      if (node.type === 'module' && (moduleFunctionCounts.get(node.id) || 0) > 10) {
+        affectedModules.push(node.id);
+      }
+    }
 
-    if (modulesWithManyFunctions.length > 0) {
+    if (affectedModules.length > 0) {
       insights.push({
         id: 'i-1',
         type: 'refactor',
         title: 'God Object Detected',
-        description: `Found ${modulesWithManyFunctions.length} modules containing a large number of functions. Consider splitting them.`,
+        description: `Found ${affectedModules.length} modules containing a large number of functions. Consider splitting them.`,
         severity: 'high',
-        affectedNodes: modulesWithManyFunctions.map(n => n.id)
+        affectedNodes: affectedModules
       });
     }
 
     // 2. High coupling
     const moduleDependencies = new Map<string, number>();
-    graph.links.forEach(l => {
+    for (const l of graph.links) {
       if (l.type === 'import' && l.source.startsWith('module:') && l.target.startsWith('module:')) {
         moduleDependencies.set(l.source, (moduleDependencies.get(l.source) || 0) + 1);
       }
-    });
+    }
+
+    // ⚡ Bolt Optimization: Single O(N) pass, eliminating chained Array.from().filter().map() allocations
+    const highlyCoupled: string[] = [];
+    for (const [id, count] of moduleDependencies.entries()) {
+      if (count > 15) highlyCoupled.push(id);
+    }
     
-    const highlyCoupled = Array.from(moduleDependencies.entries()).filter(([_, count]) => count > 15).map(([id]) => id);
     if (highlyCoupled.length > 0) {
       insights.push({
         id: 'i-2',

--- a/src/analyzer/parser.ts
+++ b/src/analyzer/parser.ts
@@ -1214,7 +1214,7 @@ export class CodeAnalyzer {
     // Mock AI Insights generation based on simple heuristics
     
     // 1. Large files / God objects
-    // ⚡ Bolt Optimization: Replace O(N*E) nested array filter with O(E) precomputed Map and O(1) lookups
+
     const moduleFunctionCounts = new Map<string, number>();
     for (const l of graph.links) {
       if (l.type === 'contains' && l.target.startsWith('function')) {
@@ -1222,7 +1222,7 @@ export class CodeAnalyzer {
       }
     }
 
-    // ⚡ Bolt Optimization: Single O(N) pass, eliminating chained Array.from().filter().map() allocations
+
     const affectedModules: string[] = [];
     for (const node of this.nodes.values()) {
       if (node.type === 'module' && (moduleFunctionCounts.get(node.id) || 0) > 10) {
@@ -1249,7 +1249,7 @@ export class CodeAnalyzer {
       }
     }
 
-    // ⚡ Bolt Optimization: Single O(N) pass, eliminating chained Array.from().filter().map() allocations
+
     const highlyCoupled: string[] = [];
     for (const [id, count] of moduleDependencies.entries()) {
       if (count > 15) highlyCoupled.push(id);

--- a/src/presentation/mcpServer.ts
+++ b/src/presentation/mcpServer.ts
@@ -2984,6 +2984,16 @@ def register(ctx):
             }
           }
 
+          const modules: Array<{ id: string, name: string, file?: string }> = [];
+          const classes: Array<{ id: string, name: string, file?: string, line?: number }> = [];
+          const functions: Array<{ id: string, name: string, file?: string, line?: number }> = [];
+
+          for (const n of nodes) {
+            if (n.type === "module") modules.push({ id: n.id, name: n.label, file: n.filePath });
+            else if (n.type === "class") classes.push({ id: n.id, name: n.label, file: n.filePath, line: n.line });
+            else if (n.type === "function") functions.push({ id: n.id, name: n.label, file: n.filePath, line: n.line });
+          }
+
           const summary = {
             version: 1,
             exportedAt: new Date().toISOString(),

--- a/src/presentation/mcpServer.ts
+++ b/src/presentation/mcpServer.ts
@@ -2984,16 +2984,6 @@ def register(ctx):
             }
           }
 
-          const modules: Array<{ id: string, name: string, file?: string }> = [];
-          const classes: Array<{ id: string, name: string, file?: string, line?: number }> = [];
-          const functions: Array<{ id: string, name: string, file?: string, line?: number }> = [];
-
-          for (const n of nodes) {
-            if (n.type === "module") modules.push({ id: n.id, name: n.label, file: n.filePath });
-            else if (n.type === "class") classes.push({ id: n.id, name: n.label, file: n.filePath, line: n.line });
-            else if (n.type === "function") functions.push({ id: n.id, name: n.label, file: n.filePath, line: n.line });
-          }
-
           const summary = {
             version: 1,
             exportedAt: new Date().toISOString(),


### PR DESCRIPTION
💡 **What:** Replaced chained `Array.from().filter().map()` calls with single `for...of` loops in `src/analyzer/parser.ts` for AI insight generation.

🎯 **Why:** To eliminate intermediate array allocations and redundant iterations, turning an O(N) operation with high overhead into a leaner O(N) pass, saving memory and processing time during graph analysis.

📊 **Impact:** Reduces garbage collection pressure and memory usage during graph analysis by directly populating result arrays instead of creating and discarding intermediate arrays.

🔬 **Measurement:** Code correctly compiles, and tests pass as verified by `npm run build` and `npm run test`.

---
*PR created automatically by Jules for task [1012077412810626124](https://jules.google.com/task/1012077412810626124) started by @giauphan*