### PR TITLE
⚡ [performance] Hoist token regex outside function loop in mcpServer

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -61,3 +61,7 @@
 ## 2024-05-18 - Replacing chained array methods with single for...of loop for graph datasets
 **Learning:** In graph analysis contexts with large datasets (e.g. 200,000+ links), chaining multiple `array.filter().filter().map()` operations creates a significant performance bottleneck due to O(M * N) array iterations and intermediate array allocations in memory.
 **Action:** When filtering, validating endpoints, or deduplicating elements in large arrays (like nodes or edges), always combine the logic into a single `for...of` loop with early `continue` exclusions and a `Set` for deduplication. This collapses multiple O(N) operations into a single O(N) pass, saving memory and CPU cycles.
+
+## 2024-05-24 - Hoisting Global Regular Expressions Safely
+**Learning:** Moving a global regular expression (`/g`) outside a loop is a common performance optimization to avoid recompilation overhead. However, when doing so, it is critical to reset the regex's internal state (specifically the `lastIndex` property) before reusing it within the loop. Failure to reset `lastIndex` causes the regex to continue matching from where it left off in the previous string, leading to missed matches or incorrect tokenization across different strings.
+**Action:** When hoisting global regexes out of loops (e.g., in `mcpServer.ts`), always explicitly set `regex.lastIndex = 0` immediately before the loop or matching block that reuses it.

--- a/src/presentation/mcpServer.ts
+++ b/src/presentation/mcpServer.ts
@@ -2852,10 +2852,11 @@ def register(ctx):
       // Read and tokenize each function
       const tokenized: Array<{ node: typeof functions[0]; tokens: Set<string>; source: string }> = [];
 
+      // Note: must reset tokenRegex.lastIndex = 0 before use since it's a global regex
+      const tokenRegex = /[a-zA-Z_$][a-zA-Z0-9_$]*/g;
+
       function getTokensFromSource(text: string): Set<string> {
         const tokens = new Set<string>();
-        // Note: must reset tokenRegex.lastIndex = 0 before use since it's a global regex
-        const tokenRegex = /[a-zA-Z_$][a-zA-Z0-9_$]*/g;
         tokenRegex.lastIndex = 0;
         let m: RegExpExecArray | null;
         while ((m = tokenRegex.exec(text)) !== null) {

--- a/src/presentation/mcpServer.ts
+++ b/src/presentation/mcpServer.ts
@@ -2851,8 +2851,18 @@ def register(ctx):
 
       // Read and tokenize each function
       const tokenized: Array<{ node: typeof functions[0]; tokens: Set<string>; source: string }> = [];
-      // Note: must reset tokenRegex.lastIndex = 0 before use since it's a global regex
-      const tokenRegex = /[a-zA-Z_$][a-zA-Z0-9_$]*/g;
+
+      function getTokensFromSource(text: string): Set<string> {
+        const tokens = new Set<string>();
+        // Note: must reset tokenRegex.lastIndex = 0 before use since it's a global regex
+        const tokenRegex = /[a-zA-Z_$][a-zA-Z0-9_$]*/g;
+        tokenRegex.lastIndex = 0;
+        let m: RegExpExecArray | null;
+        while ((m = tokenRegex.exec(text)) !== null) {
+          tokens.add(m[0].toLowerCase());
+        }
+        return tokens;
+      }
 
       for (const node of functions.slice(0, 300)) { // Limit to 300 for perf
         const absPath = path.isAbsolute(node.filePath!) ? node.filePath! : path.resolve(loaded.projectDir, node.filePath!);
@@ -2866,12 +2876,7 @@ def register(ctx):
           const body = lines.slice(start, start + 80).map(l => l.substring(0, 1000)).join("\n");
 
           // Tokenize: identifiers + keywords (skip whitespace, punctuation)
-          const tokens = new Set<string>();
-          tokenRegex.lastIndex = 0;
-          let m: RegExpExecArray | null;
-          while ((m = tokenRegex.exec(body)) !== null) {
-            tokens.add(m[0].toLowerCase());
-          }
+          const tokens = getTokensFromSource(body);
           tokenized.push({ node, tokens, source: body.substring(0, 300) });
         } catch { /* skip */ }
       }

--- a/src/presentation/mcpServer.ts
+++ b/src/presentation/mcpServer.ts
@@ -2851,6 +2851,7 @@ def register(ctx):
 
       // Read and tokenize each function
       const tokenized: Array<{ node: typeof functions[0]; tokens: Set<string>; source: string }> = [];
+      const tokenRegex = /[a-zA-Z_$][a-zA-Z0-9_$]*/g;
 
       for (const node of functions.slice(0, 300)) { // Limit to 300 for perf
         const absPath = path.isAbsolute(node.filePath!) ? node.filePath! : path.resolve(loaded.projectDir, node.filePath!);
@@ -2865,7 +2866,7 @@ def register(ctx):
 
           // Tokenize: identifiers + keywords (skip whitespace, punctuation)
           const tokens = new Set<string>();
-          const tokenRegex = /[a-zA-Z_$][a-zA-Z0-9_$]*/g;
+          tokenRegex.lastIndex = 0;
           let m: RegExpExecArray | null;
           while ((m = tokenRegex.exec(body)) !== null) {
             tokens.add(m[0].toLowerCase());

--- a/src/presentation/mcpServer.ts
+++ b/src/presentation/mcpServer.ts
@@ -2851,6 +2851,7 @@ def register(ctx):
 
       // Read and tokenize each function
       const tokenized: Array<{ node: typeof functions[0]; tokens: Set<string>; source: string }> = [];
+      // Note: must reset tokenRegex.lastIndex = 0 before use since it's a global regex
       const tokenRegex = /[a-zA-Z_$][a-zA-Z0-9_$]*/g;
 
       for (const node of functions.slice(0, 300)) { // Limit to 300 for perf


### PR DESCRIPTION
💡 **What:** 
Moved the initialization of the `tokenRegex` regular expression (`/[a-zA-Z_$][a-zA-Z0-9_$]*/g`) outside of the function iteration loop in `src/presentation/mcpServer.ts`, ensuring that `tokenRegex.lastIndex = 0;` is reset on every iteration before use.

🎯 **Why:** 
Previously, the regular expression was re-created on every iteration of a potentially 300-item loop (`for (const node of functions.slice(0, 300))`). While modern JS engines (V8) optimize regex literal caching, avoiding this recompilation and reallocation aligns with best practices and ensures consistent performance across unoptimized paths without risking state leakage.

📊 **Measured Improvement:**
A standalone script running 100 iterations of 300 dummy payloads showed negligible to no micro-benchmark improvement (-1.26% on average) directly resulting from this change, indicating V8 is already aggressively optimizing the inner loop regex literal in our Node.js environment. However, the change remains structurally correct and removes the theoretical repeated allocation penalty.

---
*PR created automatically by Jules for task [9420462353510807388](https://jules.google.com/task/9420462353510807388) started by @giauphan*