### PR TITLE
🛡️ Sentinel: [HIGH] Fix string replacement injection vulnerability

### DIFF
--- a/src/presentation/mcpServer.ts
+++ b/src/presentation/mcpServer.ts
@@ -2281,7 +2281,7 @@ export function registerTools(server: McpServer) {
             if (!envContent.includes("CODEATLAS_API_KEY=")) {
               envContent += (envContent.endsWith("\n") || envContent === "" ? "" : "\n") + `CODEATLAS_API_KEY=${key}\n`;
             } else {
-              envContent = envContent.replace(/CODEATLAS_API_KEY=.*(\r?\n|$)/g, `CODEATLAS_API_KEY=${key}\n`);
+              envContent = envContent.replace(/CODEATLAS_API_KEY=.*(\r?\n|$)/g, () => `CODEATLAS_API_KEY=${key}\n`);
             }
             // Use writeFileSync with temp file to avoid race conditions (partial mitigate)
             fs.writeFileSync(envPath, envContent, { mode: 0o600 });
@@ -2982,16 +2982,6 @@ def register(ctx):
               });
               if (callGraph.length >= 500) break;
             }
-          }
-
-          const modules: Array<{ id: string, name: string, file?: string }> = [];
-          const classes: Array<{ id: string, name: string, file?: string, line?: number }> = [];
-          const functions: Array<{ id: string, name: string, file?: string, line?: number }> = [];
-
-          for (const n of nodes) {
-            if (n.type === "module") modules.push({ id: n.id, name: n.label, file: n.filePath });
-            else if (n.type === "class") classes.push({ id: n.id, name: n.label, file: n.filePath, line: n.line });
-            else if (n.type === "function") functions.push({ id: n.id, name: n.label, file: n.filePath, line: n.line });
           }
 
           const summary = {


### PR DESCRIPTION
🚨 **Severity**: HIGH
💡 **Vulnerability**: String Replacement Injection. When modifying the `.env` file content in `src/presentation/mcpServer.ts`, the `String.prototype.replace()` method was passed a dynamically constructed string containing an unvalidated environment variable (`CODEATLAS_API_KEY`). If the API key contained special replacement string patterns like `$'` (which inserts the portion of the string that follows the matched substring), it would inject and corrupt the generated configuration file.
🎯 **Impact**: Configuration file corruption leading to denial of service or unexpected behavior, particularly if attacker-controlled payloads are processed as the replacement string.
🔧 **Fix**: Modified the second argument to `String.prototype.replace()` to use a replacer function `() => \`CODEATLAS_API_KEY=\${key}\\n\`` instead of a concatenated string. This ensures the replacement is treated strictly as literal text, closing this injection vector. Cleaned up unused, duplicate variables (`modules`, `classes`, `functions`) discovered nearby in `export_team_artifact`.
✅ **Verification**: Code review passed, local test suite passed successfully. No side effects.

---
*PR created automatically by Jules for task [4799201718097699755](https://jules.google.com/task/4799201718097699755) started by @giauphan*