### PR TITLE
⚡ Bolt: Combine multiple graph link loops into a single pass in parser

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -65,6 +65,9 @@
 ## 2024-05-24 - Hoisting Global Regular Expressions Safely
 **Learning:** Moving a global regular expression (`/g`) outside a loop is a common performance optimization to avoid recompilation overhead. However, when doing so, it is critical to reset the regex's internal state (specifically the `lastIndex` property) before reusing it within the loop. Failure to reset `lastIndex` causes the regex to continue matching from where it left off in the previous string, leading to missed matches or incorrect tokenization across different strings.
 **Action:** When hoisting global regexes out of loops (e.g., in `mcpServer.ts`), always explicitly set `regex.lastIndex = 0` immediately before the loop or matching block that reuses it.
+## 2026-08-04 - [Performance improvement] Optimized O(E) double link traversal in AI Insights
+**Learning:** In `src/analyzer/parser.ts`, the `generateAIInsights` method iterated over `graph.links` twice in separate `for...of` loops to compute module function counts and module dependencies. This forced multiple full passes over the entire relationship dataset, increasing execution time and CPU overhead on large graphs.
+**Action:** When gathering multiple independent metrics from a large collection (like links in a graph), always combine them into a single pass using one `for...of` loop. Initialize the necessary `Map`s beforehand and populate them concurrently within the loop body.
 
 ## 2026-08-16 - [Performance improvement] Optimized O(N) multi-pass metric aggregation
 **Learning:** During analysis of the `index_coverage` tool in `src/presentation/mcpServer.ts`, it was discovered that generating project coverage statistics involved iterating over the `nodes` array 4 separate times (one `.filter()` and three separate `for...of` loops) to calculate valid node subsets, type distributions, file distributions, and coverage percentages.

--- a/src/analyzer/parser.ts
+++ b/src/analyzer/parser.ts
@@ -1213,11 +1213,17 @@ export class CodeAnalyzer {
     
     // Mock AI Insights generation based on simple heuristics
     
-    // 1. Large files / God objects
+    // 1. Large files / God objects & High coupling (Combined O(E) traversal)
+    // ⚡ Bolt Optimization: Combine multiple O(E) double link traversal operations into a single O(E) pass
     const moduleFunctionCounts = new Map<string, number>();
+    const moduleDependencies = new Map<string, number>();
+
     for (const l of graph.links) {
       if (l.type === 'contains' && l.target.startsWith('function')) {
         moduleFunctionCounts.set(l.source, (moduleFunctionCounts.get(l.source) || 0) + 1);
+      }
+      if (l.type === 'import' && l.source.startsWith('module:') && l.target.startsWith('module:')) {
+        moduleDependencies.set(l.source, (moduleDependencies.get(l.source) || 0) + 1);
       }
     }
 
@@ -1240,12 +1246,6 @@ export class CodeAnalyzer {
     }
 
     // 2. High coupling
-    const moduleDependencies = new Map<string, number>();
-    for (const l of graph.links) {
-      if (l.type === 'import' && l.source.startsWith('module:') && l.target.startsWith('module:')) {
-        moduleDependencies.set(l.source, (moduleDependencies.get(l.source) || 0) + 1);
-      }
-    }
 
     const highlyCoupled: string[] = [];
     for (const [id, count] of moduleDependencies.entries()) {

--- a/src/analyzer/parser.ts
+++ b/src/analyzer/parser.ts
@@ -1245,8 +1245,7 @@ export class CodeAnalyzer {
       });
     }
 
-    // 2. High coupling
-
+    // Process High coupling using previously combined O(E) loop data
     const highlyCoupled: string[] = [];
     for (const [id, count] of moduleDependencies.entries()) {
       if (count > 15) highlyCoupled.push(id);


### PR DESCRIPTION
💡 **What**: Refactored `generateAIInsights` in `src/analyzer/parser.ts` to combine two separate `O(E)` `for...of` loops iterating over `graph.links` into a single loop.
🎯 **Why**: When analyzing large projects, the AST graph contains thousands of relationships. Iterating over `graph.links` multiple times to calculate `moduleFunctionCounts` (God object detection) and `moduleDependencies` (High coupling detection) wastes CPU cycles and time.
📊 **Impact**: Reduces execution time overhead when calculating insights by reducing array iterations by 50% without affecting semantic behavior.
🔬 **Measurement**: Verified with existing test suites, test performance confirms correctness and structural robustness over large generated graphs.

---
*PR created automatically by Jules for task [10141286512759056708](https://jules.google.com/task/10141286512759056708) started by @giauphan*