### PR TITLE
🔒 Fix TOCTOU path traversal in code_search

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -31,7 +31,7 @@
 **Vulnerability:** Git commands invoked via `child_process.spawnSync` can be susceptible to argument injection if arguments are not fully trusted, even when `shell: false` is used. Git accepts global flags like `-c`, `--exec-path`, `--pager`, `--config-env`, and others that can lead to arbitrary code execution if an attacker manages to inject them.
 **Learning:** Always validate and explicitly allowlist or denylist arguments passed to external binaries like `git`, particularly those that might be influenced by external input. Explicit sanitization ensures that no unexpected or dangerous flags are processed.
 **Prevention:** Implement an explicit sanitization step (e.g., filtering out strings starting with `-c`, `--exec-path`, `--pager`, etc.) before passing the argument array to `spawnSync` when wrapping tools like `git`.
-## 2024-05-24 - TOCTOU Path Traversal in Directory Walk
+## 2024-05-24 - [TOCTOU Path Traversal in Directory Walk]
 
 **Vulnerability:** A Time-of-Check to Time-of-Use (TOCTOU) vulnerability existed in `code_search` where a file path identified as a regular file during a directory walk could be swapped with a symlink to an external sensitive file immediately before it was read, allowing an attacker to read arbitrary files outside the authorized workspace.
 

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -31,3 +31,10 @@
 **Vulnerability:** Git commands invoked via `child_process.spawnSync` can be susceptible to argument injection if arguments are not fully trusted, even when `shell: false` is used. Git accepts global flags like `-c`, `--exec-path`, `--pager`, `--config-env`, and others that can lead to arbitrary code execution if an attacker manages to inject them.
 **Learning:** Always validate and explicitly allowlist or denylist arguments passed to external binaries like `git`, particularly those that might be influenced by external input. Explicit sanitization ensures that no unexpected or dangerous flags are processed.
 **Prevention:** Implement an explicit sanitization step (e.g., filtering out strings starting with `-c`, `--exec-path`, `--pager`, etc.) before passing the argument array to `spawnSync` when wrapping tools like `git`.
+## 2024-05-24 - TOCTOU Path Traversal in Directory Walk
+
+**Vulnerability:** A Time-of-Check to Time-of-Use (TOCTOU) vulnerability existed in `code_search` where a file path identified as a regular file during a directory walk could be swapped with a symlink to an external sensitive file immediately before it was read, allowing an attacker to read arbitrary files outside the authorized workspace.
+
+**Learning:** `fs.readdir` with `withFileTypes: true` and `.isFile()` checks only reflect the state of the filesystem at the time of iteration. They do not guarantee the path is still safe (or even points to the same underlying inode) when `fs.promises.readFile` is called microseconds later.
+
+**Prevention:** When reading files discovered via directory traversal, always resolve the file path with `fs.realpathSync()` immediately before reading and verify it strictly falls within the authorized, resolved root directory using `startsWith()` (with `path.sep` appended) to prevent TOCTOU symlink attacks.

--- a/commit_message.txt
+++ b/commit_message.txt
@@ -1,0 +1,3 @@
+🔒 Fix TOCTOU path traversal in code_search
+
+Resolves a Time-of-Check to Time-of-Use path traversal vulnerability in the `code_search` MCP tool by ensuring paths read strictly belong to the intended project directory after symlink resolution.

--- a/description.txt
+++ b/description.txt
@@ -1,0 +1,12 @@
+🎯 **What:**
+Fixed a Time-of-Check to Time-of-Use (TOCTOU) path traversal vulnerability in the `code_search` MCP tool. The tool previously relied on the initial directory walk's `isFile()` check to guarantee path safety, but didn't validate the path's safety at the exact moment of reading.
+
+⚠️ **Risk:**
+An attacker could theoretically swap a legitimate file within the workspace with a symlink to an external, sensitive file (like `/etc/passwd` or ssh keys) during the fraction of a second between the directory walk identifying it and the `fs.promises.readFile` executing. This would result in the server reading the external file and returning its contents as part of the search results, leading to an arbitrary file read vulnerability.
+
+🛡️ **Solution:**
+1. Computed the absolute, symlink-resolved path of the base project directory using `fs.realpathSync`.
+2. Before reading any file discovered during the walk, the file's path is resolved using `fs.realpathSync`.
+3. Added a strict directory boundary check (`startsWith` with `path.sep` appended) to ensure the newly resolved file path still legitimately resides within the resolved project directory. If the check fails, the read is skipped.
+
+Note: A previous CI run failed due to a GitHub Advanced Security / Copilot `autofind.js` failure (`CAPIError: 400 The requested model is not supported` for `claude-opus-4.6`), which is a known external API issue and not related to the code changes. Local tests pass successfully.

--- a/src/presentation/mcpServer.ts
+++ b/src/presentation/mcpServer.ts
@@ -1705,6 +1705,13 @@ export function registerTools(server: McpServer) {
       const allFiles: string[] = [];
       const extSet = new Set([".ts", ".tsx", ".js", ".jsx", ".py", ".php", ".json", ".yaml", ".yml", ".md", ".css", ".scss", ".html"]);
 
+      let resolvedProjectDir: string;
+      try {
+        resolvedProjectDir = fs.realpathSync(loaded.projectDir);
+      } catch {
+        return { content: [{ type: "text" as const, text: JSON.stringify({ error: "Invalid project directory" }) }] };
+      }
+
       try {
         const walkDir = (dir: string, depth: number) => {
           if (depth > 8) return;
@@ -1728,7 +1735,13 @@ export function registerTools(server: McpServer) {
       for (const filePath of allFiles) {
         if (results.length >= maxRes) break;
         try {
-          const content = await fs.promises.readFile(filePath, "utf-8");
+          // Resolve file path to prevent TOCTOU symlink path traversal
+          const resolvedFilePath = fs.realpathSync(filePath);
+          if (resolvedFilePath !== resolvedProjectDir && !resolvedFilePath.startsWith(resolvedProjectDir + path.sep)) {
+            continue;
+          }
+
+          const content = await fs.promises.readFile(resolvedFilePath, "utf-8");
 
           // Fast path to skip files that definitely don't contain the query
           // This avoids expensive .split('\n') and per-line iterations for most files

--- a/src/presentation/mcpServer.ts
+++ b/src/presentation/mcpServer.ts
@@ -1753,7 +1753,7 @@ export function registerTools(server: McpServer) {
             if (results.length >= maxRes) break;
             if (searchRegex.test(lines[i])) {
               results.push({
-                file: path.relative(loaded.projectDir, filePath),
+                file: path.relative(loaded.projectDir, resolvedFilePath),
                 line: i + 1,
                 content: lines[i].trim(),
                 contextBefore: lines.slice(Math.max(0, i - ctx), i).map(l => l.trim()).filter(Boolean),


### PR DESCRIPTION
🎯 **What:**
Fixed a Time-of-Check to Time-of-Use (TOCTOU) path traversal vulnerability in the `code_search` MCP tool. The tool previously relied on the initial directory walk's `isFile()` check to guarantee path safety, but didn't validate the path's safety at the exact moment of reading.

⚠️ **Risk:**
An attacker could theoretically swap a legitimate file within the workspace with a symlink to an external, sensitive file (like `/etc/passwd` or ssh keys) during the fraction of a second between the directory walk identifying it and the `fs.promises.readFile` executing. This would result in the server reading the external file and returning its contents as part of the search results, leading to an arbitrary file read vulnerability.

🛡️ **Solution:**
1. Computed the absolute, symlink-resolved path of the base project directory using `fs.realpathSync`.
2. Before reading any file discovered during the walk, the file's path is resolved using `fs.realpathSync`.
3. Added a strict directory boundary check (`startsWith` with `path.sep` appended) to ensure the newly resolved file path still legitimately resides within the resolved project directory. If the check fails, the read is skipped.

---
*PR created automatically by Jules for task [13881034735526727022](https://jules.google.com/task/13881034735526727022) started by @giauphan*