### PR TITLE
Allow concurrent stdio MCP servers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@ pnpm-debug.log*
 .DS_Store
 # Build output
 dist/
+
+# Test coverage output
+coverage/
 .jules/
 .codeatlas/
 plan.md

--- a/index.ts
+++ b/index.ts
@@ -13,7 +13,6 @@ import * as os from "os";
 const homeDir = os.homedir();
 const logDir = path.join(homeDir, ".codeatlas");
 const logFilePath = path.join(logDir, "mcp.log");
-const legacyPidFilePath = path.join(logDir, "mcp.pid");
 
 try {
   if (!fs.existsSync(logDir)) {
@@ -23,14 +22,16 @@ try {
   // Ignore directory creation errors
 }
 
-// Versions before 3.1.1 used a global PID lock, which is incompatible with
-// stdio MCP because each client must be able to launch its own server process.
-// Remove any leftover lock file now that it is no longer used.
+// Transitional cleanup: remove the PID lock written by versions < 3.1.1.
+// That lock made later stdio MCP clients exit before initializing, so it is no
+// longer written. Safe to delete this block once 3.1.x is no longer in use.
+const legacyPidFilePath = path.join(logDir, "mcp.pid");
 try {
   fs.unlinkSync(legacyPidFilePath);
 } catch (err: any) {
+  // A missing file is the normal case for new installs.
   if (err?.code !== "ENOENT") {
-    // Ignore cleanup errors; the server does not depend on this legacy file.
+    console.error(`[Cleanup] ⚠️ Could not remove legacy PID file ${legacyPidFilePath}: ${err?.message ?? err}`);
   }
 }
 

--- a/index.ts
+++ b/index.ts
@@ -13,7 +13,6 @@ import * as os from "os";
 const homeDir = os.homedir();
 const logDir = path.join(homeDir, ".codeatlas");
 const logFilePath = path.join(logDir, "mcp.log");
-const pidFilePath = path.join(logDir, "mcp.pid");
 
 try {
   if (!fs.existsSync(logDir)) {
@@ -33,9 +32,6 @@ if (isCLICommand(process.argv)) {
 }
 // ──────────────────────────────────────────────────────────────────────
 
-// ── Single-instance PID guard ──────────────────────────────────────────
-// Prevents duplicate MCP server processes from consuming excessive memory.
-// But allow --version and --help flags to pass through.
 
 // Handle --version before PID guard
 if (process.argv.includes('--version') || process.argv.includes('-v')) {
@@ -60,34 +56,6 @@ if (process.argv.includes('--sync-dreams')) {
   process.exit(result.success ? 0 : 1);
 }
 
-if (!process.argv.includes('--help') && !process.argv.includes('-h')) {
-  try {
-    if (fs.existsSync(pidFilePath)) {
-      const existingPid = parseInt(fs.readFileSync(pidFilePath, "utf-8").trim(), 10);
-      if (!isNaN(existingPid) && existingPid > 0) {
-        try {
-          process.kill(existingPid, 0); // Check if alive
-          // Another instance is already running. Exit immediately to avoid duplicates.
-          // DO NOT kill the old instance — that would break the active MCP connection
-          // and cause Hermes to reconnect in an infinite kill-restart loop.
-          console.error(`[PID-Guard] 🔒 Instance already running (PID: ${existingPid}). New instance exiting.`);
-          process.exit(0);
-        } catch (e: any) {
-          if (e?.code === 'ESRCH') {
-            console.error(`[PID-Guard] 🗑️ Stale PID ${existingPid} — old instance is gone. Starting fresh.`);
-          } else {
-            console.error(`[PID-Guard] ⚠️ Cannot verify PID ${existingPid}. Will overwrite.`);
-          }
-        }
-      }
-    }
-    fs.writeFileSync(pidFilePath, String(process.pid));
-    console.error(`[PID-Guard] 🔒 Lock acquired (PID: ${process.pid})`);
-  } catch (err) {
-    console.error(`[PID-Guard] ⚠️ Could not write PID file — running without guard: ${err}`);
-  }
-}
-// ────────────────────────────────────────────────────────────────────────
 
 // ⚠️ NOTE: API key must be set via CODEATLAS_API_KEY environment variable or .env file.
 // Passing API keys via command-line arguments is NOT supported — they are visible
@@ -276,7 +244,7 @@ async function main() {
 main().catch(console.error);
 
 // ── Graceful shutdown handlers ─────────────────────────────────────────
-// Prevent zombie processes by cleaning up watchers, cache, and PID file.
+// Stop watcher resources when this stdio connection closes.
 function cleanup(signal: string) {
   console.error(`[Cleanup] 🧹 Received ${signal}. Shutting down...`);
   try {
@@ -284,14 +252,7 @@ function cleanup(signal: string) {
   } catch (e) {
     console.error(`[Cleanup] ⚠️ Watcher cleanup error: ${e}`);
   }
-  try {
-    if (fs.existsSync(pidFilePath)) {
-      fs.unlinkSync(pidFilePath);
-      console.error(`[Cleanup] 🗑️ PID file removed.`);
-    }
-  } catch (e) {
-    console.error(`[Cleanup] ⚠️ PID file cleanup error: ${e}`);
-  }
+
   process.exit(0);
 }
 

--- a/index.ts
+++ b/index.ts
@@ -13,6 +13,7 @@ import * as os from "os";
 const homeDir = os.homedir();
 const logDir = path.join(homeDir, ".codeatlas");
 const logFilePath = path.join(logDir, "mcp.log");
+const legacyPidFilePath = path.join(logDir, "mcp.pid");
 
 try {
   if (!fs.existsSync(logDir)) {
@@ -20,6 +21,17 @@ try {
   }
 } catch (err) {
   // Ignore directory creation errors
+}
+
+// Versions before 3.1.1 used a global PID lock, which is incompatible with
+// stdio MCP because each client must be able to launch its own server process.
+// Remove any leftover lock file now that it is no longer used.
+try {
+  fs.unlinkSync(legacyPidFilePath);
+} catch (err: any) {
+  if (err?.code !== "ENOENT") {
+    // Ignore cleanup errors; the server does not depend on this legacy file.
+  }
 }
 
 // ── CLI command routing ──────────────────────────────────────────────
@@ -32,8 +44,7 @@ if (isCLICommand(process.argv)) {
 }
 // ──────────────────────────────────────────────────────────────────────
 
-
-// Handle --version before PID guard
+// Handle --version before starting the MCP server.
 if (process.argv.includes('--version') || process.argv.includes('-v')) {
   // Try both relative locations (source: index.ts, dist: dist/index.js)
   let version = 'unknown';

--- a/src/presentation/stdioServer.test.ts
+++ b/src/presentation/stdioServer.test.ts
@@ -13,8 +13,17 @@ type StartedServer = {
 };
 
 function startServer(homeDir: string, projectDir: string): StartedServer {
+  const childCoverageDir = path.join(homeDir, "v8-coverage");
+  mkdirSync(childCoverageDir, { recursive: true });
   const child = spawn(process.execPath, [path.resolve("dist/index.js")], {
-    env: { ...process.env, HOME: homeDir, CODEATLAS_PROJECT_DIR: projectDir },
+    // This black-box child must not add the entire server startup path to c8's
+    // parent-process coverage report.
+    env: {
+      ...process.env,
+      HOME: homeDir,
+      CODEATLAS_PROJECT_DIR: projectDir,
+      NODE_V8_COVERAGE: childCoverageDir,
+    },
     stdio: ["pipe", "pipe", "pipe"],
   });
 

--- a/src/presentation/stdioServer.test.ts
+++ b/src/presentation/stdioServer.test.ts
@@ -1,6 +1,8 @@
 import assert from "node:assert/strict";
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import { once } from "node:events";
+import { existsSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import process from "node:process";
 import test from "node:test";
@@ -10,32 +12,42 @@ type StartedServer = {
   response: Promise<Record<string, unknown>>;
 };
 
-function startServer(): StartedServer {
+function startServer(homeDir: string, projectDir: string): StartedServer {
   const child = spawn(process.execPath, [path.resolve("dist/index.js")], {
+    env: { ...process.env, HOME: homeDir, CODEATLAS_PROJECT_DIR: projectDir },
     stdio: ["pipe", "pipe", "pipe"],
   });
 
   const response = new Promise<Record<string, unknown>>((resolve, reject) => {
     let output = "";
-    const timeout = setTimeout(() => {
-      reject(new Error("MCP initialize response timed out"));
-    }, 10_000);
-
-    child.once("error", (error) => {
+    let stderr = "";
+    let settled = false;
+    const fail = (message: string, cause?: unknown) => {
+      if (settled) return;
+      settled = true;
       clearTimeout(timeout);
-      reject(error);
-    });
+      const details = stderr.trim() ? `\nstderr:\n${stderr.trim()}` : "";
+      reject(new Error(`${message}${details}`, { cause }));
+    };
+    const timeout = setTimeout(() => fail("MCP initialize response timed out"), 10_000);
 
+    child.once("error", (error) => fail("MCP server failed to start", error));
+    child.once("exit", (code, signal) => {
+      if (!settled) fail(`MCP server exited before initialize (code: ${code}, signal: ${signal})`);
+    });
+    child.stderr.on("data", (chunk: Buffer) => { stderr += chunk.toString(); });
     child.stdout.on("data", (chunk: Buffer) => {
       output += chunk.toString();
       const lineEnd = output.indexOf("\n");
-      if (lineEnd === -1) return;
+      if (lineEnd === -1 || settled) return;
 
-      clearTimeout(timeout);
       try {
-        resolve(JSON.parse(output.slice(0, lineEnd)));
+        const parsed = JSON.parse(output.slice(0, lineEnd));
+        settled = true;
+        clearTimeout(timeout);
+        resolve(parsed);
       } catch (error) {
-        reject(error);
+        fail("MCP server wrote an invalid initialize response", error);
       }
     });
   });
@@ -60,21 +72,38 @@ async function stopServer(child: ChildProcessWithoutNullStreams): Promise<void> 
   await once(child, "exit");
 }
 
-test("multiple stdio MCP servers complete initialize", async () => {
-  const first = startServer();
-  const second = startServer();
+test("multiple stdio MCP servers complete initialize", async (t) => {
+  const tempDir = mkdtempSync(path.join(os.tmpdir(), "codeatlas-mcp-test-"));
+  const firstHome = path.join(tempDir, "first-home");
+  const secondHome = path.join(tempDir, "second-home");
+  const projectDir = path.join(tempDir, "project");
+  mkdirSync(firstHome);
+  mkdirSync(secondHome);
+  mkdirSync(projectDir);
 
-  try {
-    const [firstResponse, secondResponse] = await Promise.all([
-      first.response,
-      second.response,
-    ]);
+  const firstLegacyPid = path.join(firstHome, ".codeatlas", "mcp.pid");
+  const secondLegacyPid = path.join(secondHome, ".codeatlas", "mcp.pid");
+  mkdirSync(path.dirname(firstLegacyPid), { recursive: true });
+  mkdirSync(path.dirname(secondLegacyPid), { recursive: true });
+  writeFileSync(firstLegacyPid, "1234");
+  writeFileSync(secondLegacyPid, "5678");
 
-    assert.equal(firstResponse.jsonrpc, "2.0");
-    assert.equal(secondResponse.jsonrpc, "2.0");
-    assert.equal((firstResponse.result as { serverInfo: { name: string } }).serverInfo.name, "CodeAtlas");
-    assert.equal((secondResponse.result as { serverInfo: { name: string } }).serverInfo.name, "CodeAtlas");
-  } finally {
+  const first = startServer(firstHome, projectDir);
+  const second = startServer(secondHome, projectDir);
+  t.after(async () => {
     await Promise.all([stopServer(first.child), stopServer(second.child)]);
-  }
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  const [firstResponse, secondResponse] = await Promise.all([
+    first.response,
+    second.response,
+  ]);
+
+  assert.equal(firstResponse.jsonrpc, "2.0");
+  assert.equal(secondResponse.jsonrpc, "2.0");
+  assert.equal(existsSync(firstLegacyPid), false);
+  assert.equal(existsSync(secondLegacyPid), false);
+  assert.equal((firstResponse.result as { serverInfo: { name: string } }).serverInfo.name, "CodeAtlas");
+  assert.equal((secondResponse.result as { serverInfo: { name: string } }).serverInfo.name, "CodeAtlas");
 });

--- a/src/presentation/stdioServer.test.ts
+++ b/src/presentation/stdioServer.test.ts
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { once } from "node:events";
+import path from "node:path";
+import process from "node:process";
+import test from "node:test";
+
+type StartedServer = {
+  child: ChildProcessWithoutNullStreams;
+  response: Promise<Record<string, unknown>>;
+};
+
+function startServer(): StartedServer {
+  const child = spawn(process.execPath, [path.resolve("dist/index.js")], {
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+
+  const response = new Promise<Record<string, unknown>>((resolve, reject) => {
+    let output = "";
+    const timeout = setTimeout(() => {
+      reject(new Error("MCP initialize response timed out"));
+    }, 10_000);
+
+    child.once("error", (error) => {
+      clearTimeout(timeout);
+      reject(error);
+    });
+
+    child.stdout.on("data", (chunk: Buffer) => {
+      output += chunk.toString();
+      const lineEnd = output.indexOf("\n");
+      if (lineEnd === -1) return;
+
+      clearTimeout(timeout);
+      try {
+        resolve(JSON.parse(output.slice(0, lineEnd)));
+      } catch (error) {
+        reject(error);
+      }
+    });
+  });
+
+  child.stdin.write(`${JSON.stringify({
+    jsonrpc: "2.0",
+    id: 1,
+    method: "initialize",
+    params: {
+      protocolVersion: "2024-11-05",
+      capabilities: {},
+      clientInfo: { name: "stdio-regression-test", version: "1.0.0" },
+    },
+  })}\n`);
+
+  return { child, response };
+}
+
+async function stopServer(child: ChildProcessWithoutNullStreams): Promise<void> {
+  if (child.exitCode !== null) return;
+  child.kill("SIGTERM");
+  await once(child, "exit");
+}
+
+test("multiple stdio MCP servers complete initialize", async () => {
+  const first = startServer();
+  const second = startServer();
+
+  try {
+    const [firstResponse, secondResponse] = await Promise.all([
+      first.response,
+      second.response,
+    ]);
+
+    assert.equal(firstResponse.jsonrpc, "2.0");
+    assert.equal(secondResponse.jsonrpc, "2.0");
+    assert.equal((firstResponse.result as { serverInfo: { name: string } }).serverInfo.name, "CodeAtlas");
+    assert.equal((secondResponse.result as { serverInfo: { name: string } }).serverInfo.name, "CodeAtlas");
+  } finally {
+    await Promise.all([stopServer(first.child), stopServer(second.child)]);
+  }
+});


### PR DESCRIPTION
## Summary
- remove the global PID lock that caused later stdio MCP clients to exit before completing initialization
- remove legacy mcp.pid files left by previous releases
- add isolated concurrent stdio initialization coverage with child-process diagnostics

## Validation
- npm run lint
- npm run build
- node --experimental-test-module-mocks --test dist/src/presentation/stdioServer.test.js