### PR TITLE
⚡ Bolt: optimize /proc parsing with early exit

### DIFF
--- a/src/services/projectService.ts
+++ b/src/services/projectService.ts
@@ -346,8 +346,17 @@ export function getOpenIdeForDir(dir: string): string | null {
     const absPath = path.resolve(dir.trim());
     if (!fs.existsSync('/proc')) return null;
     const files = fs.readdirSync('/proc');
-    // Safety: only scan up to 500 process entries to prevent abuse
-    const pidEntries = files.filter(f => /^\d+$/.test(f)).slice(0, 500);
+    // Safety: only scan up to 500 process entries to prevent abuse.
+    // Optimized filtering with an early exit to avoid scanning and evaluating
+    // unnecessary entries in large directories.
+    const pidEntries: string[] = [];
+    const pidRegex = /^\d+$/;
+    for (const f of files) {
+      if (pidRegex.test(f)) {
+        pidEntries.push(f);
+        if (pidEntries.length >= 500) break;
+      }
+    }
     for (const file of pidEntries) {
       const pid = file;
       const cmdlinePath = `/proc/${pid}/cmdline`;


### PR DESCRIPTION
Replaces the chained filter().slice(0,500) over /proc entries with a single loop that early-exits once 500 pid entries are collected, avoiding scanning the full directory on busy hosts.

Reimplements the meaningful change from #160 on top of current main. #160's branch was far behind and its diff would have reverted unrelated work (CI workflows, package-lock, hooks), so it is superseded by this clean PR.

Verified: tsc --noEmit passes; test suite passes except a pre-existing stdioServer flake unrelated to this change.