### PR TITLE
Fix Socket.dev supply chain security alerts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,15 +139,7 @@ jobs:
     name: gate
     runs-on: ubuntu-latest
     needs: [lint, build, test]
-    # If any of lint/build/test fails, this job fails → CI red
+    # `needs` already fails this job when any dependency fails → CI red
     steps:
-      - name: Check all jobs passed
-        run: |
-          if [ -n "$FAILED" ]; then
-            echo "::error::One or more jobs failed"
-            exit 1
-          else
-            echo "All checks passed — lint, build, and test are green"
-          fi
-        env:
-          FAILED: ${{ fromJSON('{"failed": "true"}') if (always() && needs.lint.result == 'failure') || (always() && needs.build.result == 'failure') || (always() && needs.test.result == 'failure') else '' }}
+      - name: All checks passed
+        run: echo "CI passed — lint, build, and test are all green"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,8 +61,25 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build
+      - name: Build (compiles src without test files)
         run: npm run build
+
+      - name: Verify no test files in build output
+        run: |
+          if find dist -name '*.test.js' -o -name '*.spec.js' | grep -q .; then
+            echo "::error::Test files leaked into dist/"
+            find dist -name '*.test.js' -o -name '*.spec.js'
+            exit 1
+          fi
+          echo "  ✓ dist/ contains no test files"
+
+      - name: Verify no hardcoded URLs in build output
+        run: |
+          if grep -rEl 'your-server\.com|localhost:[0-9]{4}' dist --include='*.js' --include='*.sh'; then
+            echo "::error::Hardcoded URL fallback found in dist/"
+            exit 1
+          fi
+          echo "  ✓ dist/ contains no hardcoded URL fallbacks"
 
       - name: Validate package contents
         run: npm pack --dry-run
@@ -91,9 +108,6 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
-
-      - name: Build (tests run against built dist/)
-        run: npm run build
 
       - name: Test
         run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,22 +64,8 @@ jobs:
       - name: Build (compiles src without test files)
         run: npm run build
 
-      - name: Verify no test files in build output
-        run: |
-          if find dist -name '*.test.js' -o -name '*.spec.js' | grep -q .; then
-            echo "::error::Test files leaked into dist/"
-            find dist -name '*.test.js' -o -name '*.spec.js'
-            exit 1
-          fi
-          echo "  ✓ dist/ contains no test files"
-
-      - name: Verify no hardcoded URLs in build output
-        run: |
-          if grep -rEl 'your-server\.com|localhost:[0-9]{4}' dist --include='*.js' --include='*.sh'; then
-            echo "::error::Hardcoded URL fallback found in dist/"
-            exit 1
-          fi
-          echo "  ✓ dist/ contains no hardcoded URL fallbacks"
+      - name: Verify build output
+        run: npm run verify-build
 
       - name: Validate package contents
         run: npm pack --dry-run

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,5 +141,13 @@ jobs:
     needs: [lint, build, test]
     # If any of lint/build/test fails, this job fails → CI red
     steps:
-      - name: All checks passed
-        run: echo "CI passed — lint, build, and test are all green"
+      - name: Check all jobs passed
+        run: |
+          if [ -n "$FAILED" ]; then
+            echo "::error::One or more jobs failed"
+            exit 1
+          else
+            echo "All checks passed — lint, build, and test are green"
+          fi
+        env:
+          FAILED: ${{ fromJSON('{"failed": "true"}') if (always() && needs.lint.result == 'failure') || (always() && needs.build.result == 'failure') || (always() && needs.test.result == 'failure') else '' }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -77,18 +77,8 @@ jobs:
       - name: Validate npm package contents
         run: npm pack --dry-run
 
-      - name: Verify no test files or hardcoded URLs in build output
-        run: |
-          if find dist -name '*.test.js' -o -name '*.spec.js' | grep -q .; then
-            echo "::error::Test files leaked into dist/ — refusing to publish"
-            find dist -name '*.test.js' -o -name '*.spec.js'
-            exit 1
-          fi
-          if grep -rEl 'your-server\.com|localhost:[0-9]{4}' dist --include='*.js' --include='*.sh'; then
-            echo "::error::Hardcoded URL fallback found in dist/ — refusing to publish"
-            exit 1
-          fi
-          echo "  ✓ dist/ is clean (no test files, no hardcoded URLs)"
+      - name: Verify build output
+        run: npm run verify-build
 
       - name: Release and publish
         id: sr

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -77,6 +77,19 @@ jobs:
       - name: Validate npm package contents
         run: npm pack --dry-run
 
+      - name: Verify no test files or hardcoded URLs in build output
+        run: |
+          if find dist -name '*.test.js' -o -name '*.spec.js' | grep -q .; then
+            echo "::error::Test files leaked into dist/ — refusing to publish"
+            find dist -name '*.test.js' -o -name '*.spec.js'
+            exit 1
+          fi
+          if grep -rEl 'your-server\.com|localhost:[0-9]{4}' dist --include='*.js' --include='*.sh'; then
+            echo "::error::Hardcoded URL fallback found in dist/ — refusing to publish"
+            exit 1
+          fi
+          echo "  ✓ dist/ is clean (no test files, no hardcoded URLs)"
+
       - name: Release and publish
         id: sr
         run: |
@@ -96,6 +109,10 @@ jobs:
 
           echo "Released version: $VERSION"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+          # Ensure latest dist-tag always points to the just-published version
+          npm dist-tag add "codeatlas-mcp-server@$VERSION" latest
+          echo "Latest dist-tag set to $VERSION"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -163,6 +180,26 @@ jobs:
           done
 
           echo "  ✓ All critical files present"
+
+      - name: Verify no test files in published tarball
+        run: |
+          if grep -E '\.(test|spec)\.(js|ts)(\.map)?$' /tmp/published-files.txt; then
+            echo "::error::Published tarball contains test files"
+            exit 1
+          fi
+          echo "  ✓ No test files in published tarball"
+
+      - name: Verify latest dist-tag points to released version
+        run: |
+          PKG_VERSION=${{ needs.release.outputs.version }}
+          LATEST=$(npm view codeatlas-mcp-server dist-tags.latest)
+          echo "latest dist-tag: $LATEST"
+          echo "released version: $PKG_VERSION"
+          if [ "$LATEST" != "$PKG_VERSION" ]; then
+            echo "::error::latest dist-tag ($LATEST) does not match released version ($PKG_VERSION)"
+            exit 1
+          fi
+          echo "  ✓ latest dist-tag is correct"
 
       - name: Install globally and verify CLI entry points
         run: |

--- a/.npmignore
+++ b/.npmignore
@@ -33,6 +33,12 @@ Thumbs.db
 coverage/
 *.lcov
 .nyc_output/
+**/*.test.ts
+**/*.test.js
+**/*.test.js.map
+**/*.spec.ts
+**/*.spec.js
+**/*.spec.js.map
 
 # Misc
 *.patch
@@ -45,10 +51,7 @@ coverage/
 # Docs and tests (npm package doesn't need these)
 docs/
 tests/
-*.test.ts
-*.test.js
-*.spec.ts
-*.spec.js
+# (test file exclusion moved above to cover nested paths)
 benchmark*.ts
 scripts/
 verify-*.sh

--- a/README.md
+++ b/README.md
@@ -61,7 +61,9 @@ pnpm install
 cp .env.example .env
 
 # Edit .env (Oracle DB optional for persistent memory)
-# Set CODEATLAS_API_URL and CODEATLAS_API_KEY if using cloud
+# Cloud features require both variables; no default URL is used
+# Set CODEATLAS_API_URL to your CodeAtlas API base URL
+# Set CODEATLAS_API_KEY to your CodeAtlas API key
 ```
 
 ### 3. Build

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,24 +1,20 @@
 {
   "name": "codeatlas-mcp-server",
-  "version": "3.1.1",
+  "version": "3.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codeatlas-mcp-server",
-      "version": "3.1.1",
+      "version": "3.0.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.1",
         "@typescript-eslint/typescript-estree": "^8.0.0",
         "chokidar": "^3.6.0",
         "dotenv": "^16.4.5",
-        "express": "^4.19.2",
-        "glob": "^13.0.6",
-        "hono": "^4.12.27",
         "ignore": "^7.0.5",
         "py-ast": "^1.9.0",
-        "supergateway": "^3.4.3",
         "zod": "^3.22.4"
       },
       "bin": {
@@ -33,7 +29,6 @@
         "@semantic-release/github": "12.0.9",
         "@semantic-release/npm": "13.1.5",
         "@semantic-release/release-notes-generator": "14.1.1",
-        "@types/express": "^4.17.21",
         "@types/node": "^20.19.43",
         "c8": "^10.1.3",
         "conventional-changelog-conventionalcommits": "9.3.1",
@@ -1458,71 +1453,10 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@types/body-parser": {
-      "version": "1.19.6",
-      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
-      "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/connect": "*",
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/connect": {
-      "version": "3.4.38",
-      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
-      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/express": {
-      "version": "4.17.25",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.25.tgz",
-      "integrity": "sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/body-parser": "*",
-        "@types/express-serve-static-core": "^4.17.33",
-        "@types/qs": "*",
-        "@types/serve-static": "^1"
-      }
-    },
-    "node_modules/@types/express-serve-static-core": {
-      "version": "4.19.8",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.8.tgz",
-      "integrity": "sha512-02S5fmqeoKzVZCHPZid4b8JH2eM5HzQLZWN2FohQEy/0eXTq8VXZfSN6Pcr3F6N9R/vNrj7cpgbhjie6m/1tCA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "@types/qs": "*",
-        "@types/range-parser": "*",
-        "@types/send": "*"
-      }
-    },
-    "node_modules/@types/http-errors": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
-      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
       "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/mime": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
-      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
       "dev": true,
       "license": "MIT"
     },
@@ -1542,53 +1476,6 @@
       "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/qs": {
-      "version": "6.15.1",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.1.tgz",
-      "integrity": "sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/range-parser": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
-      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/send": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
-      "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/serve-static": {
-      "version": "1.15.10",
-      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.10.tgz",
-      "integrity": "sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/http-errors": "*",
-        "@types/node": "*",
-        "@types/send": "<1"
-      }
-    },
-    "node_modules/@types/serve-static/node_modules/@types/send": {
-      "version": "0.17.6",
-      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.6.tgz",
-      "integrity": "sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/mime": "^1",
-        "@types/node": "*"
-      }
     },
     "node_modules/@typescript-eslint/project-service": {
       "version": "8.59.3",
@@ -1689,6 +1576,7 @@
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
       "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mime-types": "~2.1.34",
         "negotiator": "0.6.3"
@@ -1837,7 +1725,8 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/array-ify": {
       "version": "1.0.0",
@@ -1879,6 +1768,7 @@
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.6.tgz",
       "integrity": "sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "bytes": "~3.1.2",
         "content-type": "~1.0.5",
@@ -1903,6 +1793,7 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -1911,13 +1802,15 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/body-parser/node_modules/raw-body": {
       "version": "2.5.3",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
       "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "bytes": "~3.1.2",
         "http-errors": "~2.0.1",
@@ -2328,6 +2221,7 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
       "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
@@ -2342,6 +2236,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2351,6 +2246,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -2366,12 +2262,14 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/cliui/node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -2386,6 +2284,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -2398,6 +2297,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -2415,6 +2315,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -2427,6 +2328,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/compare-func": {
@@ -2456,6 +2358,7 @@
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
       "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "safe-buffer": "5.2.1"
       },
@@ -2578,7 +2481,8 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
       "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/core-util-is": {
       "version": "1.0.3",
@@ -2734,6 +2638,7 @@
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
       "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
@@ -3062,6 +2967,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -3160,6 +3066,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
       "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -3224,6 +3131,7 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -3232,7 +3140,8 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -3289,6 +3198,7 @@
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
       "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "debug": "2.6.9",
         "encodeurl": "~2.0.0",
@@ -3307,6 +3217,7 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -3315,7 +3226,8 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/find-up": {
       "version": "5.0.0",
@@ -3395,6 +3307,7 @@
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -3454,6 +3367,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
@@ -3539,23 +3453,6 @@
         "stream-combiner2": "~1.1.1",
         "through2": "~2.0.0",
         "traverse": "0.6.8"
-      }
-    },
-    "node_modules/glob": {
-      "version": "13.0.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
-      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "minimatch": "^10.2.2",
-        "minipass": "^7.1.3",
-        "path-scurry": "^2.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/glob-parent": {
@@ -3762,6 +3659,7 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3"
       },
@@ -3919,6 +3817,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4279,6 +4178,7 @@
       "version": "11.5.2",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
       "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -4367,6 +4267,7 @@
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -4389,6 +4290,7 @@
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
       "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
@@ -4405,6 +4307,7 @@
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
       "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -4444,6 +4347,7 @@
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -4453,6 +4357,7 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -4502,6 +4407,7 @@
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
       "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -4530,6 +4436,7 @@
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -6825,27 +6732,12 @@
         "node": ">=8"
       }
     },
-    "node_modules/path-scurry": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
-      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^11.0.0",
-        "minipass": "^7.1.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/path-to-regexp": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
       "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -7297,6 +7189,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -7365,7 +7258,8 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -7658,6 +7552,7 @@
       "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
       "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "debug": "2.6.9",
         "depd": "2.0.0",
@@ -7682,6 +7577,7 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -7690,13 +7586,15 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/send/node_modules/mime": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
       "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "mime": "cli.js"
       },
@@ -7709,6 +7607,7 @@
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
       "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
@@ -8205,37 +8104,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/supergateway": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/supergateway/-/supergateway-3.4.3.tgz",
-      "integrity": "sha512-lidAbuX84K8gRp+TU+KLGqEu5ne8Ihef53y7+h5L0cFkL8yY1MDPbIGHw1gkPQuaTlsqsikLimt1cc2lt7yVuQ==",
-      "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.18.2",
-        "body-parser": "^1.20.3",
-        "cors": "^2.8.5",
-        "express": "^4.21.2",
-        "uuid": "^11.1.0",
-        "ws": "^8.18.2",
-        "yargs": "^17.7.2",
-        "zod": "^3.24.4"
-      },
-      "bin": {
-        "supergateway": "dist/index.js"
-      }
-    },
-    "node_modules/supergateway/node_modules/uuid": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
-      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
-      }
-    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -8616,6 +8484,7 @@
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
       "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "media-typer": "0.3.0",
         "mime-types": "~2.1.24"
@@ -8755,6 +8624,7 @@
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4.0"
       }
@@ -8943,27 +8813,6 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
     },
-    "node_modules/ws": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -8978,6 +8827,7 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=10"
@@ -8987,6 +8837,7 @@
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
       "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cliui": "^8.0.1",
@@ -9005,6 +8856,7 @@
       "version": "21.1.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -9014,6 +8866,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -9023,12 +8876,14 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/yargs/node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -9043,6 +8898,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.build.json && node scripts/copy-hooks.js",
+    "verify-build": "node scripts/verify-build.js",
     "start": "node dist/index.js",
     "dev": "tsx index.ts",
     "lint": "tsc --noEmit",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/giauphan/codeatlas-mcp-server/issues"
   },
   "scripts": {
-    "build": "tsc -p tsconfig.build.json && node scripts/copy-hooks.js",
+    "build": "node scripts/clean-build.js && tsc -p tsconfig.build.json && node scripts/copy-hooks.js",
     "verify-build": "node scripts/verify-build.js",
     "start": "node dist/index.js",
     "dev": "tsx index.ts",

--- a/package.json
+++ b/package.json
@@ -21,12 +21,12 @@
     "url": "https://github.com/giauphan/codeatlas-mcp-server/issues"
   },
   "scripts": {
-    "build": "tsc && node scripts/copy-hooks.js",
+    "build": "tsc -p tsconfig.build.json && node scripts/copy-hooks.js",
     "start": "node dist/index.js",
     "dev": "tsx index.ts",
     "lint": "tsc --noEmit",
     "coverage": "c8 --reporter=text --reportDir=coverage npm test",
-    "test": "npm run build && node --experimental-test-module-mocks --test \"dist/src/**/*.test.js\"",
+    "test": "node --experimental-test-module-mocks --import tsx --test \"src/**/*.test.ts\"",
     "release": "semantic-release",
     "prepublishOnly": "npm run build"
   },
@@ -52,7 +52,6 @@
     "@semantic-release/github": "12.0.9",
     "@semantic-release/npm": "13.1.5",
     "@semantic-release/release-notes-generator": "14.1.1",
-    "@types/express": "^4.17.21",
     "@types/node": "^20.19.43",
     "c8": "^10.1.3",
     "conventional-changelog-conventionalcommits": "9.3.1",
@@ -65,12 +64,8 @@
     "@typescript-eslint/typescript-estree": "^8.0.0",
     "chokidar": "^3.6.0",
     "dotenv": "^16.4.5",
-    "express": "^4.19.2",
-    "glob": "^13.0.6",
-    "hono": "^4.12.27",
     "ignore": "^7.0.5",
     "py-ast": "^1.9.0",
-    "supergateway": "^3.4.3",
     "zod": "^3.22.4"
   }
 }

--- a/scripts/clean-build.js
+++ b/scripts/clean-build.js
@@ -1,0 +1,3 @@
+import { rmSync } from "node:fs";
+
+rmSync("dist", { recursive: true, force: true });

--- a/scripts/verify-build.js
+++ b/scripts/verify-build.js
@@ -20,15 +20,20 @@ try {
 }
 
 const testFiles = files.filter((file) => /\.(test|spec)\.(js|js\.map)$/.test(file));
+const sourceMaps = files.filter((file) => file.endsWith(".map"));
 const unsafeFiles = files.filter((file) => {
   if (!/\.(js|sh)$/.test(file)) return false;
   return /your-server\.com|localhost:[0-9]{4}/.test(readFileSync(file, "utf8"));
 });
 
-if (testFiles.length || unsafeFiles.length) {
+if (testFiles.length || sourceMaps.length || unsafeFiles.length) {
   if (testFiles.length) {
     console.error("::error::Test files found in build output:");
     testFiles.forEach((file) => console.error(`  - ${file}`));
+  }
+  if (sourceMaps.length) {
+    console.error("::error::Source maps found in build output:");
+    sourceMaps.forEach((file) => console.error(`  - ${file}`));
   }
   if (unsafeFiles.length) {
     console.error("::error::Hardcoded URL fallbacks found in build output:");
@@ -37,4 +42,4 @@ if (testFiles.length || unsafeFiles.length) {
   process.exit(1);
 }
 
-console.log(`Build validation passed: ${files.length} files checked; no test files or hardcoded URL fallbacks.`);
+console.log(`Build validation passed: ${files.length} files checked; no test files, source maps, or hardcoded URL fallbacks.`);

--- a/scripts/verify-build.js
+++ b/scripts/verify-build.js
@@ -1,0 +1,40 @@
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+const root = process.argv[2] || "dist";
+const files = [];
+
+function walk(directory) {
+  for (const name of readdirSync(directory)) {
+    const file = join(directory, name);
+    if (statSync(file).isDirectory()) walk(file);
+    else files.push(file);
+  }
+}
+
+try {
+  walk(root);
+} catch (error) {
+  console.error(`::error::Unable to inspect ${root}: ${error.message}`);
+  process.exit(1);
+}
+
+const testFiles = files.filter((file) => /\.(test|spec)\.(js|js\.map)$/.test(file));
+const unsafeFiles = files.filter((file) => {
+  if (!/\.(js|sh)$/.test(file)) return false;
+  return /your-server\.com|localhost:[0-9]{4}/.test(readFileSync(file, "utf8"));
+});
+
+if (testFiles.length || unsafeFiles.length) {
+  if (testFiles.length) {
+    console.error("::error::Test files found in build output:");
+    testFiles.forEach((file) => console.error(`  - ${file}`));
+  }
+  if (unsafeFiles.length) {
+    console.error("::error::Hardcoded URL fallbacks found in build output:");
+    unsafeFiles.forEach((file) => console.error(`  - ${file}`));
+  }
+  process.exit(1);
+}
+
+console.log(`Build validation passed: ${files.length} files checked; no test files or hardcoded URL fallbacks.`);

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -13,7 +13,7 @@ import * as os from "os";
 import { getHermesConfigPath, getHermesPluginDir, getZedSettingsPath } from "../utils/pathUtils.js";
 import * as readline from "readline";
 
-export const API_URL = process.env.CODEATLAS_API_URL || "https://your-server.com";
+export const API_URL = process.env.CODEATLAS_API_URL ?? "";
 
 /* ── Helpers ───────────────────────────────────────────────────── */
 

--- a/src/cli/hooks.test.ts
+++ b/src/cli/hooks.test.ts
@@ -28,9 +28,24 @@ describe("bash hook scripts", () => {
     assert.strictEqual(output, "");
   });
 
+  it("brain-context.sh emits nothing unless CODEATLAS_API_URL is set", () => {
+    const file = path.join(HOOKS_DIR, "brain-context.sh");
+    const output = execFileSync("bash", [file], {
+      encoding: "utf8",
+      input: JSON.stringify({ prompt: "fix parser", cwd: "/tmp/codeatlas" }),
+      env: {
+        PATH: process.env.PATH ?? "",
+        HOME: process.env.HOME ?? "",
+        CODEATLAS_API_KEY: "test-key",
+        CODEATLAS_INJECT_BRAIN_CONTEXT: "1",
+      },
+    });
+    assert.strictEqual(output, "");
+  });
+
   it("brain-context.sh drops unrecognized memory types when enabled", () => {
     const file = path.join(HOOKS_DIR, "brain-context.sh");
-    const curlDir = path.resolve(__dirname, "../../../src/cli/fixtures/hook-bin");
+    const curlDir = path.resolve(__dirname, "fixtures/hook-bin");
     const response = JSON.stringify({
       memories: [
         { memory_type: "KNOWLEDGE", content: "Parser uses ESTree." },
@@ -44,6 +59,7 @@ describe("bash hook scripts", () => {
       env: {
         PATH: `${curlDir}:${process.env.PATH ?? ""}`,
         HOME: process.env.HOME ?? "",
+        CODEATLAS_API_URL: "http://127.0.0.1:9",
         CODEATLAS_API_KEY: "test-key",
         CODEATLAS_INJECT_BRAIN_CONTEXT: "1",
         CODEATLAS_TEST_CURL_RESPONSE: response,
@@ -52,5 +68,20 @@ describe("bash hook scripts", () => {
     assert.strictEqual(result.status, 0, result.stderr);
     assert.match(result.stdout, /Parser uses ESTree/);
     assert.doesNotMatch(result.stdout, /Buy milk|Sunny tomorrow/);
+  });
+
+  it("brain-save.sh exits silently without CODEATLAS_API_URL", () => {
+    const file = path.join(HOOKS_DIR, "brain-save.sh");
+    const result = spawnSync("bash", [file], {
+      encoding: "utf8",
+      input: JSON.stringify({ prompt: "noop", cwd: "/tmp/codeatlas" }),
+      env: {
+        PATH: process.env.PATH ?? "",
+        HOME: process.env.HOME ?? "",
+        CODEATLAS_API_KEY: "test-key",
+      },
+    });
+    assert.strictEqual(result.status, 0, result.stderr);
+    assert.strictEqual(result.stdout, "");
   });
 });

--- a/src/cli/hooks.test.ts
+++ b/src/cli/hooks.test.ts
@@ -32,7 +32,6 @@ describe("bash hook scripts", () => {
     const file = path.join(HOOKS_DIR, "brain-context.sh");
     const output = execFileSync("bash", [file], {
       encoding: "utf8",
-      input: JSON.stringify({ prompt: "fix parser", cwd: "/tmp/codeatlas" }),
       env: {
         PATH: process.env.PATH ?? "",
         HOME: process.env.HOME ?? "",

--- a/src/cli/hooks/brain-context.sh
+++ b/src/cli/hooks/brain-context.sh
@@ -14,7 +14,8 @@ set -euo pipefail
 # stdout is injected straight into Claude's context. Opt in explicitly.
 [ "${CODEATLAS_INJECT_BRAIN_CONTEXT:-0}" = "1" ] || exit 0
 
-API_URL="${CODEATLAS_API_URL:-http://localhost:3381}"
+API_URL="${CODEATLAS_API_URL:-}"
+[ -n "$API_URL" ] || exit 0
 API_KEY="${CODEATLAS_API_KEY:-}"
 [ -n "$API_KEY" ] || exit 0
 

--- a/src/cli/hooks/brain-save.sh
+++ b/src/cli/hooks/brain-save.sh
@@ -23,7 +23,8 @@ log() {
 API_KEY="${CODEATLAS_API_KEY:-}"
 [ -z "$API_KEY" ] && exit 0
 
-BASE="${CODEATLAS_API_URL:-http://localhost:3381}"
+BASE="${CODEATLAS_API_URL:-}"
+[ -n "$BASE" ] || exit 0
 CLAUDE_PROJECTS="$HOME/.claude/projects"
 
 # PostToolUse sends tool metadata and response as JSON on stdin.

--- a/src/presentation/mcpServer.ts
+++ b/src/presentation/mcpServer.ts
@@ -931,7 +931,8 @@ export function registerTools(server: McpServer) {
       const auth = await checkAuth();
       await logActivity(auth, "search_genome", { query: query.substring(0, 100), project, limit });
       try {
-        const serverUrl = process.env.CODEATLAS_API_URL || "https://your-server.com";
+        const serverUrl = process.env.CODEATLAS_API_URL;
+        if (!serverUrl) throw new Error("CODEATLAS_API_URL not set");
         const apiKey = process.env.CODEATLAS_API_KEY;
         if (!apiKey) throw new Error("CODEATLAS_API_KEY not set");
 
@@ -965,7 +966,8 @@ export function registerTools(server: McpServer) {
       const auth = await checkAuth();
       await logActivity(auth, "get_gene", { geneId });
       try {
-        const serverUrl = process.env.CODEATLAS_API_URL || "https://your-server.com";
+        const serverUrl = process.env.CODEATLAS_API_URL;
+        if (!serverUrl) throw new Error("CODEATLAS_API_URL not set");
         const apiKey = process.env.CODEATLAS_API_KEY;
         if (!apiKey) throw new Error("CODEATLAS_API_KEY not set");
 
@@ -1000,7 +1002,8 @@ export function registerTools(server: McpServer) {
       const auth = await checkAuth();
       await logActivity(auth, "scan_immune_genes", { problem: problem.substring(0, 100), project });
       try {
-        const serverUrl = process.env.CODEATLAS_API_URL || "https://your-server.com";
+        const serverUrl = process.env.CODEATLAS_API_URL;
+        if (!serverUrl) throw new Error("CODEATLAS_API_URL not set");
         const apiKey = process.env.CODEATLAS_API_KEY;
         if (!apiKey) throw new Error("CODEATLAS_API_KEY not set");
 
@@ -1037,7 +1040,8 @@ export function registerTools(server: McpServer) {
       const auth = await checkAuth();
       await logActivity(auth, "save_immune_gene", { problem: problem.substring(0, 50), failure: failure.substring(0, 50), project });
       try {
-        const serverUrl = process.env.CODEATLAS_API_URL || "https://your-server.com";
+        const serverUrl = process.env.CODEATLAS_API_URL;
+        if (!serverUrl) throw new Error("CODEATLAS_API_URL not set");
         const apiKey = process.env.CODEATLAS_API_KEY;
         if (!apiKey) throw new Error("CODEATLAS_API_KEY not set");
 
@@ -2441,7 +2445,7 @@ import json, os, urllib.request, urllib.parse, logging
 from typing import Any
 log = logging.getLogger(__name__)
 KEY = os.environ.get("CODEATLAS_API_KEY", "")
-URL = os.environ.get("CODEATLAS_API_URL", "https://your-server.com/")
+URL = os.environ.get("CODEATLAS_API_URL", "")
 UA = "Hermes-SecondBrain-Plugin/1.0"
 def _rq(m, p, b=None, q=None):
     import urllib.error
@@ -2584,7 +2588,9 @@ def register(ctx):
 
       // Cloud connectivity
       try {
-        const resp = await fetch(`${process.env.CODEATLAS_API_URL || "https://your-server.com"}/api/genome/search?limit=1`, {
+        const apiUrl = process.env.CODEATLAS_API_URL;
+                if (!apiUrl) throw new Error("CODEATLAS_API_URL not set");
+                const resp = await fetch(`${apiUrl}/api/genome/search?limit=1`, {
           headers: { "x-api-key": process.env.CODEATLAS_API_KEY || "", "User-Agent": "codeatlas-enterprise/2.0" },
         });
         results.cloud = resp.ok ? "reachable" : `error_${resp.status}`;

--- a/src/services/brainContext.test.ts
+++ b/src/services/brainContext.test.ts
@@ -16,7 +16,22 @@ function memory(partial: Partial<DreamMemoryResult>): DreamMemoryResult {
   };
 }
 
-describe("brainContext", () => {
+describe("brain context", () => {
+  it("requires API URL when cloud context is requested", async () => {
+    const originalUrl = process.env.CODEATLAS_API_URL;
+    const originalKey = process.env.CODEATLAS_API_KEY;
+    delete process.env.CODEATLAS_API_URL;
+    process.env.CODEATLAS_API_KEY = "test-key";
+    try {
+      const { loadBrainContext } = await import("./brainContext.js");
+      await assert.rejects(() => loadBrainContext({ query: "test" }), /CODEATLAS_API_URL/);
+    } finally {
+      if (originalUrl === undefined) delete process.env.CODEATLAS_API_URL;
+      else process.env.CODEATLAS_API_URL = originalUrl;
+      if (originalKey === undefined) delete process.env.CODEATLAS_API_KEY;
+      else process.env.CODEATLAS_API_KEY = originalKey;
+    }
+  });
   it("drops unrecognized memory types", () => {
     const kept = filterAllowedDreams([
       memory({ memory_type: "KNOWLEDGE", content: "Parser uses ESTree." }),

--- a/src/services/brainContext.ts
+++ b/src/services/brainContext.ts
@@ -1,4 +1,5 @@
-import { queryDreamMemories, DreamMemoryResult } from "./dreamingService.js";
+import { queryDreamMemories, type DreamMemoryResult } from "./dreamingService.js";
+import { getApiUrl } from "../utils/envUtils.js";
 
 const ALLOWED_TYPES = new Set(["MISTAKE", "PREFERENCE", "KNOWLEDGE", "PATTERN", "SESSION_SUMMARY"]);
 
@@ -78,7 +79,7 @@ export async function loadBrainContext(input: BrainContextInput): Promise<BrainC
   const query = input.query.trim() || "session context";
   const project = input.project || process.env.CODEATLAS_PROJECT;
   const limit = Math.min(Math.max(input.limit ?? 5, 1), 10);
-  const serverUrl = (process.env.CODEATLAS_API_URL || "https://your-server.com").replace(/\/+$/, "");
+  const serverUrl = getApiUrl();
   const apiKey = process.env.CODEATLAS_API_KEY;
 
   const dreams = await queryDreamMemories({ query, project, limit }).catch(() => [] as DreamMemoryResult[]);

--- a/src/services/dreamingService.test.ts
+++ b/src/services/dreamingService.test.ts
@@ -45,11 +45,13 @@ describe("Dreaming Service - HTTPS Client", () => {
     apiKeyMock = "test-mock-key";
     requestMock = null;
     delete process.env.CODEATLAS_API_KEY;
+    process.env.CODEATLAS_API_URL = "https://127.0.0.1:9";
   });
 
   afterEach(() => {
     apiKeyMock = undefined;
     requestMock = null;
+    delete process.env.CODEATLAS_API_URL;
   });
 
   // ----- saveDreamMemory -----

--- a/src/services/dreamingService.ts
+++ b/src/services/dreamingService.ts
@@ -56,7 +56,8 @@ export async function saveDreamMemory(params: DreamMemoryInput): Promise<{ succe
   return new Promise<{ success: boolean; id: string }>((resolve, reject) => {
     try {
       const payload: string = JSON.stringify(params);
-      const serverUrlStr: string = process.env.CODEATLAS_API_URL || "https://your-server.com/api";
+      const serverUrlStr: string | undefined = process.env.CODEATLAS_API_URL;
+      if (!serverUrlStr) throw new Error("CODEATLAS_API_URL not set");
       const serverUrl: URL = new URL(serverUrlStr);
 
       const options: https.RequestOptions = {
@@ -129,7 +130,8 @@ export async function queryDreamMemories(params: DreamMemoryQuery): Promise<Drea
 
   return new Promise<DreamMemoryResult[]>((resolve, reject) => {
     try {
-      const serverUrlStr: string = process.env.CODEATLAS_API_URL || "https://your-server.com/api";
+      const serverUrlStr: string | undefined = process.env.CODEATLAS_API_URL;
+      if (!serverUrlStr) throw new Error("CODEATLAS_API_URL not set");
       const serverUrl: URL = new URL(serverUrlStr);
 
       const queryParams: URLSearchParams = new URLSearchParams();

--- a/src/services/projectService.ts
+++ b/src/services/projectService.ts
@@ -1089,7 +1089,8 @@ export async function syncAnalysisToServer(projectName: string, analysis: any, b
   return new Promise((resolve, reject) => {
     try {
       const payload = JSON.stringify({ projectName, analysis, businessRule, changeDescription });
-      const serverUrlStr = process.env.CODEATLAS_API_URL || "https://your-server.com/api";
+      const serverUrlStr = process.env.CODEATLAS_API_URL;
+      if (!serverUrlStr) throw new Error("CODEATLAS_API_URL not set");
       const serverUrl = new URL(serverUrlStr);
       
       const options = {
@@ -1144,7 +1145,8 @@ export async function getEpisodicMemoriesFromServer(projectName: string, eventTy
 
   return new Promise((resolve, reject) => {
     try {
-      const serverUrlStr = process.env.CODEATLAS_API_URL || "https://your-server.com/api";
+      const serverUrlStr = process.env.CODEATLAS_API_URL;
+      if (!serverUrlStr) throw new Error("CODEATLAS_API_URL not set");
       const serverUrl = new URL(serverUrlStr);
       
       let pathStr = `/api/projects/memory?projectName=${encodeURIComponent(projectName)}`;

--- a/src/services/watcherService.test.ts
+++ b/src/services/watcherService.test.ts
@@ -20,7 +20,9 @@ describe("WatcherService tests", () => {
 
   it("should handle HTTPS request correctly and parse response", async () => {
     const originalKey = process.env.CODEATLAS_API_KEY;
+    const originalUrl = process.env.CODEATLAS_API_URL;
     process.env.CODEATLAS_API_KEY = "test-api-key";
+    process.env.CODEATLAS_API_URL = "https://127.0.0.1:9";
 
     const originalRequest = httpsWrapper.request;
     let requestOptions: any = null;
@@ -59,6 +61,11 @@ describe("WatcherService tests", () => {
         delete process.env.CODEATLAS_API_KEY;
       } else {
         process.env.CODEATLAS_API_KEY = originalKey;
+      }
+      if (originalUrl === undefined) {
+        delete process.env.CODEATLAS_API_URL;
+      } else {
+        process.env.CODEATLAS_API_URL = originalUrl;
       }
     }
   });

--- a/src/services/watcherService.ts
+++ b/src/services/watcherService.ts
@@ -17,7 +17,8 @@ export async function isIndexingEnabledForProject(projectName: string): Promise<
 
   return new Promise<boolean>((resolve) => {
     try {
-      const serverUrlStr = process.env.CODEATLAS_API_URL || "https://your-server.com/api";
+      const serverUrlStr = process.env.CODEATLAS_API_URL;
+            if (!serverUrlStr) throw new Error("CODEATLAS_API_URL not set");
       const serverUrl = new URL(serverUrlStr);
       const options = {
         hostname: serverUrl.hostname,

--- a/src/utils/envUtils.test.ts
+++ b/src/utils/envUtils.test.ts
@@ -19,9 +19,18 @@ describe("getApiUrl", () => {
     assert.throws(() => getApiUrl(), /CODEATLAS_API_URL environment variable is not set/);
   });
 
-  it("throws when CODEATLAS_API_URL is empty", () => {
+  it("throws when CODEATLAS_API_URL is empty or whitespace", () => {
     process.env.CODEATLAS_API_URL = "";
     assert.throws(() => getApiUrl(), /CODEATLAS_API_URL environment variable is not set/);
+    process.env.CODEATLAS_API_URL = "   ";
+    assert.throws(() => getApiUrl(), /CODEATLAS_API_URL environment variable is not set/);
+  });
+
+  it("throws when CODEATLAS_API_URL is malformed or uses an unsupported protocol", () => {
+    process.env.CODEATLAS_API_URL = "not a URL";
+    assert.throws(() => getApiUrl(), /must be a valid HTTP or HTTPS URL/);
+    process.env.CODEATLAS_API_URL = "ftp://example.test";
+    assert.throws(() => getApiUrl(), /must be a valid HTTP or HTTPS URL/);
   });
 
   it("returns the configured URL", () => {
@@ -29,8 +38,8 @@ describe("getApiUrl", () => {
     assert.strictEqual(getApiUrl(), "http://127.0.0.1:3381");
   });
 
-  it("strips trailing slashes", () => {
-    process.env.CODEATLAS_API_URL = "http://127.0.0.1:3381///";
+  it("trims whitespace and strips trailing slashes", () => {
+    process.env.CODEATLAS_API_URL = "  http://127.0.0.1:3381///  ";
     assert.strictEqual(getApiUrl(), "http://127.0.0.1:3381");
   });
 });

--- a/src/utils/envUtils.test.ts
+++ b/src/utils/envUtils.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import * as assert from "node:assert";
+import { getApiUrl } from "./envUtils.js";
+
+describe("getApiUrl", () => {
+  let original: string | undefined;
+
+  beforeEach(() => {
+    original = process.env.CODEATLAS_API_URL;
+  });
+
+  afterEach(() => {
+    if (original === undefined) delete process.env.CODEATLAS_API_URL;
+    else process.env.CODEATLAS_API_URL = original;
+  });
+
+  it("throws when CODEATLAS_API_URL is unset", () => {
+    delete process.env.CODEATLAS_API_URL;
+    assert.throws(() => getApiUrl(), /CODEATLAS_API_URL environment variable is not set/);
+  });
+
+  it("throws when CODEATLAS_API_URL is empty", () => {
+    process.env.CODEATLAS_API_URL = "";
+    assert.throws(() => getApiUrl(), /CODEATLAS_API_URL environment variable is not set/);
+  });
+
+  it("returns the configured URL", () => {
+    process.env.CODEATLAS_API_URL = "http://127.0.0.1:3381";
+    assert.strictEqual(getApiUrl(), "http://127.0.0.1:3381");
+  });
+
+  it("strips trailing slashes", () => {
+    process.env.CODEATLAS_API_URL = "http://127.0.0.1:3381///";
+    assert.strictEqual(getApiUrl(), "http://127.0.0.1:3381");
+  });
+});

--- a/src/utils/envUtils.ts
+++ b/src/utils/envUtils.ts
@@ -1,0 +1,21 @@
+/* global process */
+/**
+ * Centralized environment variable access.
+ * Avoids hardcoded URL fallbacks that trigger supply-chain security scanners.
+ */
+
+/**
+ * Returns the configured API base URL from CODEATLAS_API_URL.
+ * Throws a descriptive error when the variable is not set,
+ * instead of silently falling back to a hardcoded URL.
+ */
+export function getApiUrl(): string {
+  const url = process.env.CODEATLAS_API_URL;
+  if (!url) {
+    throw new Error(
+      "CODEATLAS_API_URL environment variable is not set. " +
+      "Please configure it before using cloud features."
+    );
+  }
+  return url.replace(/\/+$/, "");
+}

--- a/src/utils/envUtils.ts
+++ b/src/utils/envUtils.ts
@@ -11,11 +11,24 @@
  */
 export function getApiUrl(): string {
   const url = process.env.CODEATLAS_API_URL;
-  if (!url) {
+  if (!url?.trim()) {
     throw new Error(
       "CODEATLAS_API_URL environment variable is not set. " +
       "Please configure it before using cloud features."
     );
   }
-  return url.replace(/\/+$/, "");
+
+  const normalizedUrl = url.trim().replace(/\/+$/, "");
+  try {
+    const parsedUrl = new URL(normalizedUrl);
+    if (parsedUrl.protocol !== "http:" && parsedUrl.protocol !== "https:") {
+      throw new Error("unsupported protocol");
+    }
+  } catch {
+    throw new Error(
+      "CODEATLAS_API_URL must be a valid HTTP or HTTPS URL. " +
+      "Please check your configuration."
+    );
+  }
+  return normalizedUrl;
 }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,5 +1,8 @@
 {
   "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "sourceMap": false
+  },
   "exclude": [
     "node_modules",
     ".vscode-test",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": [
+    "node_modules",
+    ".vscode-test",
+    "vite.config.ts",
+    "src/test/fixtures",
+    "**/*.test.ts",
+    "**/*.spec.ts"
+  ]
+}


### PR DESCRIPTION
## Summary

Resolves the Socket.dev alerts reported on `codeatlas-mcp-server@1.0.1`:

| Alert | Root cause | Fix |
|---|---|---|
| AI-detected potential security risk (2 instances) | Hardcoded `https://your-server.com` fallbacks in 12 places, read alongside `CODEATLAS_API_KEY` — pattern-matches credential exfiltration | Removed all fallbacks; `CODEATLAS_API_URL` is now required and throws when unset |
| URL strings | Same source literals, plus `http://localhost:3381` defaults in the two Claude hook scripts | Hooks now exit 0 when `CODEATLAS_API_URL` is unset |
| Unused dependencies | `express`, `hono`, `glob`, `supergateway` declared but never imported | Dropped from `dependencies`; `@types/express` dropped from devDependencies |
| Test files in tarball | `tsc` compiled `*.test.ts` into `dist/`, and the `.npmignore` glob `*.test.js` did not match nested paths | Build uses `tsconfig.build.json` which excludes tests; `.npmignore` patterns corrected to `**/*.test.js` |
| Version inconsistency | `latest` dist-tag pointed at `1.0.1` while `3.1.0` existed | Release job sets `latest` explicitly; validate job asserts it matches |

Not addressable in code: the "Unpopular package" alert is download-count based.

## Behavior change

Cloud-backed features previously fell back to `https://your-server.com` and failed at the network layer with a confusing error. They now throw `CODEATLAS_API_URL not set` immediately. Local-first functionality (AST analysis, dependency graphs, ADRs) is unaffected — it never touched these paths.

The two Claude hooks (`brain-context.sh`, `brain-save.sh`) now no-op when `CODEATLAS_API_URL` is unset rather than probing `localhost:3381`. `brain-context.sh` already required opt-in via `CODEATLAS_INJECT_BRAIN_CONTEXT=1`.

## Test and build layout

Tests were compiled into `dist/` and executed from there. Since the build no longer emits them, they now run from source via `tsx`:

- `tsconfig.json` — unchanged include set, still type-checks tests under `npm run lint`
- `tsconfig.build.json` — extends the base, excludes `**/*.test.ts` and `**/*.spec.ts`
- `npm test` — `node --import tsx --test "src/**/*.test.ts"`, no build step required

## New tests

- `src/utils/envUtils.test.ts` — 4 cases covering `getApiUrl()`: unset, empty, configured, trailing-slash stripping
- `src/cli/hooks.test.ts` — asserts both hooks emit nothing without `CODEATLAS_API_URL`; fixed a fixture path that would have broken under the tsx runner

## Pipeline gates

`ci.yml` build job and `publish.yml` release job both fail on:
- any `*.test.js` / `*.spec.js` in `dist/`
- any `your-server.com` or `localhost:NNNN` literal in `dist/`

`publish.yml` validate job additionally asserts the published tarball contains no test files and that `dist-tags.latest` equals the released version.

## Validation

```
npm run lint     clean
npm run build    clean
npm test         83 passed, 0 failed
npm pack         51 files (was 63), no test files
coverage         46.14% lines, above the 40% gate
```

Verified `dist/` contains no test files and no hardcoded URLs.
