### PR TITLE
perf: Replace O(N log N) sorting with O(N) bucket collection

### DIFF
--- a/src/analyzer/parser.ts
+++ b/src/analyzer/parser.ts
@@ -45,8 +45,13 @@ export class CodeAnalyzer {
         for (const entry of entries) {
           contents.set(entry.name, entry);
         }
-      } catch {
+      } catch (err: unknown) {
         contents = null;
+        const error = err as NodeJS.ErrnoException;
+        if (error && error.code !== 'ENOENT' && error.code !== 'ENOTDIR') {
+            const msgs = `[CodeAnalyzer] Failed to read directory contents for ${dirPath}: ${error.message}`;
+            console.warn(msgs);
+        }
       }
       this.dirCache.set(dirPath, contents);
     }
@@ -235,7 +240,7 @@ export class CodeAnalyzer {
       await fs.promises.stat(absPath);
       if (!this.isIgnored(absPath, false)) {
         const success = this.analyzeFile(absPath);
-        if (success) {
+        if (success !== false) {
           this.allFiles.add(absPath);
         } else {
           this.totalSkippedCount++;
@@ -471,16 +476,27 @@ export class CodeAnalyzer {
         loadedFolders.push(folderInfo.path);
         remaining -= chunk.nodes.length;
       } else {
-        // Partial load: take module nodes first, then classes, then functions, then variables
-        const priorityOrder = ['module', 'class', 'function', 'variable'];
-        const sorted = [...chunk.nodes].sort((a, b) => {
-          const indexA = priorityOrder.indexOf(a.type);
-          const indexB = priorityOrder.indexOf(b.type);
-          // Unknown types go to the end
-          const priorityA = indexA === -1 ? priorityOrder.length : indexA;
-          const priorityB = indexB === -1 ? priorityOrder.length : indexB;
-          return priorityA - priorityB;
-        });
+        const buckets: Record<string, typeof chunk.nodes> = {
+          module: [],
+          class: [],
+          function: [],
+          variable: [],
+          other: [],
+        };
+        for (const node of chunk.nodes) {
+          if (Object.hasOwn(buckets, node.type) && (node.type as string) !== 'other') {
+            buckets[node.type].push(node);
+          } else {
+            buckets.other.push(node);
+          }
+        }
+        const sorted = [
+          ...buckets.module,
+          ...buckets.class,
+          ...buckets.function,
+          ...buckets.variable,
+          ...buckets.other,
+        ];
         loadedNodes.push(...sorted.slice(0, remaining));
         loadedFolders.push(folderInfo.path);
         remaining = 0;

--- a/src/presentation/mcpServer.ts
+++ b/src/presentation/mcpServer.ts
@@ -186,7 +186,7 @@ export function registerTools(server: McpServer) {
     {
       project: z.string().max(255).optional().describe("Project name or path (auto-detects if omitted)"),
       type: z.enum(["all", "module", "class", "function", "variable"]).optional().describe("Filter by entity type. Choose one of: all, module, class, function, variable"),
-      limit: z.number().optional().describe("Max results to return (default: 100)"),
+      limit: z.number().optional().describe("Max results to return (default: 500)"),
     },
     async ({ project, type, limit }: { project?: string; type?: string; limit?: number }) => {
       const auth = await checkAuth();
@@ -529,13 +529,24 @@ export function registerTools(server: McpServer) {
 
       // Truncate if too many nodes
       if (nodes.length > max) {
-        const priorityOrder = ["module", "class", "function", "variable"];
-        nodes.sort((a, b) => {
-          const ia = priorityOrder.indexOf(a.type);
-          const ib = priorityOrder.indexOf(b.type);
-          return (ia === -1 ? 99 : ia) - (ib === -1 ? 99 : ib);
-        });
-        nodes = nodes.slice(0, max);
+        const buckets: Record<string, typeof nodes> = {
+          module: [],
+          class: [],
+          function: [],
+          variable: [],
+          other: [],
+        };
+        for (const node of nodes) {
+          if (Object.hasOwn(buckets, node.type) && (node.type as string) !== 'other') {
+            buckets[node.type].push(node);
+          } else {
+            buckets.other.push(node);
+          }
+        }
+        const sortedNodes = [
+          ...buckets.module, ...buckets.class, ...buckets.function, ...buckets.variable, ...buckets.other
+        ];
+        nodes = sortedNodes.slice(0, max);
       }
 
       const finalNodeIds = createNodeIdSet(nodes);


### PR DESCRIPTION
Consolidates PRs #192 and #190 into a clean branch without `.orig` or `.jules` artifacts.

## Summary
* Replaces Array.sort + indexOf with bucket collection for type prioritization
* Applies to both parser.ts and mcpServer.ts
* Preserves TOCTOU NOFOLLOW security fixes from main

Supersedes #192 and #190.