### PR TITLE
🛡️ Sentinel: [CRITICAL] Prevent SSRF bypass by enforcing getApiUrl() usage

### DIFF
--- a/src/presentation/mcpServer.ts
+++ b/src/presentation/mcpServer.ts
@@ -1,3 +1,4 @@
+import { getApiUrl } from "../utils/envUtils.js";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import * as fs from "fs";
@@ -947,8 +948,7 @@ export function registerTools(server: McpServer) {
       const auth = await checkAuth();
       await logActivity(auth, "search_genome", { query: query.substring(0, 100), project, limit });
       try {
-        const serverUrl = process.env.CODEATLAS_API_URL;
-        if (!serverUrl) throw new Error("CODEATLAS_API_URL not set");
+        const serverUrl = getApiUrl();
         const apiKey = process.env.CODEATLAS_API_KEY;
         if (!apiKey) throw new Error("CODEATLAS_API_KEY not set");
 
@@ -982,8 +982,7 @@ export function registerTools(server: McpServer) {
       const auth = await checkAuth();
       await logActivity(auth, "get_gene", { geneId });
       try {
-        const serverUrl = process.env.CODEATLAS_API_URL;
-        if (!serverUrl) throw new Error("CODEATLAS_API_URL not set");
+        const serverUrl = getApiUrl();
         const apiKey = process.env.CODEATLAS_API_KEY;
         if (!apiKey) throw new Error("CODEATLAS_API_KEY not set");
 
@@ -1018,8 +1017,7 @@ export function registerTools(server: McpServer) {
       const auth = await checkAuth();
       await logActivity(auth, "scan_immune_genes", { problem: problem.substring(0, 100), project });
       try {
-        const serverUrl = process.env.CODEATLAS_API_URL;
-        if (!serverUrl) throw new Error("CODEATLAS_API_URL not set");
+        const serverUrl = getApiUrl();
         const apiKey = process.env.CODEATLAS_API_KEY;
         if (!apiKey) throw new Error("CODEATLAS_API_KEY not set");
 
@@ -1056,8 +1054,7 @@ export function registerTools(server: McpServer) {
       const auth = await checkAuth();
       await logActivity(auth, "save_immune_gene", { problem: problem.substring(0, 50), failure: failure.substring(0, 50), project });
       try {
-        const serverUrl = process.env.CODEATLAS_API_URL;
-        if (!serverUrl) throw new Error("CODEATLAS_API_URL not set");
+        const serverUrl = getApiUrl();
         const apiKey = process.env.CODEATLAS_API_KEY;
         if (!apiKey) throw new Error("CODEATLAS_API_KEY not set");
 
@@ -2609,8 +2606,7 @@ def register(ctx):
 
       // Cloud connectivity
       try {
-        const apiUrl = process.env.CODEATLAS_API_URL;
-                if (!apiUrl) throw new Error("CODEATLAS_API_URL not set");
+        const apiUrl = getApiUrl();
                 const resp = await fetch(`${apiUrl}/api/genome/search?limit=1`, {
           headers: { "x-api-key": process.env.CODEATLAS_API_KEY || "", "User-Agent": "codeatlas-enterprise/2.0" },
         });

--- a/src/services/dreamingService.ts
+++ b/src/services/dreamingService.ts
@@ -1,3 +1,4 @@
+import { getApiUrl } from "../utils/envUtils.js";
 import * as https from "https";
 import * as http from "http";
 import { getResolvedApiKey } from "./projectService.js";
@@ -56,9 +57,7 @@ export async function saveDreamMemory(params: DreamMemoryInput): Promise<{ succe
   return new Promise<{ success: boolean; id: string }>((resolve, reject) => {
     try {
       const payload: string = JSON.stringify(params);
-      const serverUrlStr: string | undefined = process.env.CODEATLAS_API_URL;
-      if (!serverUrlStr) throw new Error("CODEATLAS_API_URL not set");
-      const serverUrl: URL = new URL(serverUrlStr);
+      const serverUrl: URL = new URL(getApiUrl());
 
       const options: https.RequestOptions = {
         hostname: serverUrl.hostname,
@@ -130,9 +129,7 @@ export async function queryDreamMemories(params: DreamMemoryQuery): Promise<Drea
 
   return new Promise<DreamMemoryResult[]>((resolve, reject) => {
     try {
-      const serverUrlStr: string | undefined = process.env.CODEATLAS_API_URL;
-      if (!serverUrlStr) throw new Error("CODEATLAS_API_URL not set");
-      const serverUrl: URL = new URL(serverUrlStr);
+      const serverUrl: URL = new URL(getApiUrl());
 
       const queryParams: URLSearchParams = new URLSearchParams();
       queryParams.set("query", params.query);

--- a/src/services/projectService.ts
+++ b/src/services/projectService.ts
@@ -1,3 +1,4 @@
+import { getApiUrl } from "../utils/envUtils.js";
 import * as fs from "fs";
 import * as path from "path";
 import * as https from "https";
@@ -1090,9 +1091,7 @@ export async function syncAnalysisToServer(projectName: string, analysis: any, b
   return new Promise((resolve, reject) => {
     try {
       const payload = JSON.stringify({ projectName, analysis, businessRule, changeDescription });
-      const serverUrlStr = process.env.CODEATLAS_API_URL;
-      if (!serverUrlStr) throw new Error("CODEATLAS_API_URL not set");
-      const serverUrl = new URL(serverUrlStr);
+      const serverUrl = new URL(getApiUrl());
       
       const options = {
         hostname: serverUrl.hostname,
@@ -1147,9 +1146,7 @@ export async function getEpisodicMemoriesFromServer(projectName: string, eventTy
 
   return new Promise((resolve, reject) => {
     try {
-      const serverUrlStr = process.env.CODEATLAS_API_URL;
-      if (!serverUrlStr) throw new Error("CODEATLAS_API_URL not set");
-      const serverUrl = new URL(serverUrlStr);
+      const serverUrl = new URL(getApiUrl());
       
       let pathStr = `/api/projects/memory?projectName=${encodeURIComponent(projectName)}`;
       if (eventType) {

--- a/src/services/watcherService.ts
+++ b/src/services/watcherService.ts
@@ -1,3 +1,4 @@
+import { getApiUrl } from "../utils/envUtils.js";
 import chokidar from 'chokidar';
 import * as path from 'path';
 import * as https from 'https';
@@ -22,9 +23,7 @@ export async function isIndexingEnabledForProject(projectName: string): Promise<
 
   return new Promise<boolean>((resolve) => {
     try {
-      const serverUrlStr = process.env.CODEATLAS_API_URL;
-            if (!serverUrlStr) throw new Error("CODEATLAS_API_URL not set");
-      const serverUrl = new URL(serverUrlStr);
+      const serverUrl = new URL(getApiUrl());
       const options = {
         hostname: serverUrl.hostname,
         port: serverUrl.port || (serverUrl.protocol === "https:" ? 443 : 80),


### PR DESCRIPTION
## Summary
- Replaces direct `process.env.CODEATLAS_API_URL` reads in core TypeScript network code with the hardened `getApiUrl()` helper
- Ensures attacker-controlled hosts (like AWS IMDS or random websites) cannot bypass the intended loopback/HTTPS restrictions

This addresses a bypass introduced and found post-merge of #205.

## Test plan
- Run tests and ensure cloud endpoints use the restrictive URL policy
- Ensure CI pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)