### PR TITLE
🔒 Sentinel: High Fix Path Traversal in API Key Save

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -36,3 +36,9 @@
 **Vulnerability:** The `export_team_artifact` tool used `fs.writeFileSync` to write `artifact-summary.json` and `artifact.json`. Despite comments indicating an intention to "Prevent symlink following on the output file itself", `fs.writeFileSync` intrinsically follows symlinks, leaving the application vulnerable to symlink-based TOCTOU (Time-of-Check to Time-of-Use) attacks where an attacker could overwrite arbitrary system files by pre-creating symlinks.
 **Learning:** Comments indicating security intent are not sufficient if the underlying API does not support the required semantics. `fs.writeFileSync` cannot be instructed to ignore symlinks via string flags like `"w"`.
 **Prevention:** To prevent TOCTOU and symlink following vulnerabilities when writing files, avoid `fs.writeFileSync(..., { flag: "w" })`. Instead, obtain a secure file descriptor using `fs.openSync` with the explicit `fs.constants.O_NOFOLLOW` flag alongside `O_CREAT | O_WRONLY | O_TRUNC`, write to the descriptor, and ensure it is reliably closed (e.g., using a `try...finally` block).
+
+## 2024-05-27 - Fix Path Traversal via symlink bypasses in fs.realpathSync string boundary checks
+
+**Vulnerability:** Path traversal check relying on `startsWith()` against resolved paths from `fs.realpathSync()` can be circumvented. For instance, `/home/user/.codeatlas_malicious` starts with `/home/user`.
+**Learning:** Using `startsWith()` for path boundary enforcement is inadequate and vulnerable to partial string matches.
+**Prevention:** Use exact path matching where the full path is deterministic (e.g. `=== path.join(resolvedHome, '.codeatlas')`), or guarantee boundary integrity using the OS path separator for non-deterministic paths.

--- a/src/presentation/mcpServer.ts
+++ b/src/presentation/mcpServer.ts
@@ -2386,7 +2386,7 @@ export function registerTools(server: McpServer) {
           const expectedCodeatlasDir = path.join(realHomeDir, ".codeatlas");
 
           if (realCodeatlasDir !== expectedCodeatlasDir) {
-            throw new Error("Path traversal detected: .codeatlas directory must be exactly inside home directory");
+            throw new Error(`Path traversal detected: .codeatlas directory must be exactly inside home directory. Expected: ${expectedCodeatlasDir}, Actual: ${realCodeatlasDir}`);
           }
 
           const envPath = path.join(realCodeatlasDir, ".env");

--- a/src/presentation/mcpServer.ts
+++ b/src/presentation/mcpServer.ts
@@ -2381,6 +2381,8 @@ export function registerTools(server: McpServer) {
             fs.mkdirSync(codeatlasDir, { recursive: true, mode: 0o700 });
           }
 
+          // Prevent path traversal by strictly validating that the resolved .codeatlas directory
+          // resides exactly within the resolved home directory, preventing symlink bypasses.
           const realCodeatlasDir = fs.realpathSync(codeatlasDir);
           const realHomeDir = fs.realpathSync(homeDir);
           const expectedCodeatlasDir = path.join(realHomeDir, ".codeatlas");

--- a/src/presentation/mcpServer.ts
+++ b/src/presentation/mcpServer.ts
@@ -2380,7 +2380,16 @@ export function registerTools(server: McpServer) {
           if (!fs.existsSync(codeatlasDir)) {
             fs.mkdirSync(codeatlasDir, { recursive: true, mode: 0o700 });
           }
-          const envPath = path.join(codeatlasDir, ".env");
+
+          const realCodeatlasDir = fs.realpathSync(codeatlasDir);
+          const realHomeDir = fs.realpathSync(homeDir);
+          const expectedCodeatlasDir = path.join(realHomeDir, ".codeatlas");
+
+          if (realCodeatlasDir !== expectedCodeatlasDir) {
+            throw new Error("Path traversal detected: .codeatlas directory must be exactly inside home directory");
+          }
+
+          const envPath = path.join(realCodeatlasDir, ".env");
           let envContent = "";
           let fileExists = false;
           try {
@@ -2398,10 +2407,9 @@ export function registerTools(server: McpServer) {
             } else {
               envContent = envContent.replace(/CODEATLAS_API_KEY=.*(\r?\n|$)/g, () => `CODEATLAS_API_KEY=${key}\n`);
             }
-            // Use writeFileSync with temp file to avoid race conditions (partial mitigate)
-            fs.writeFileSync(envPath, envContent, { mode: 0o600 });
+            writeFileSyncNoFollow(envPath, envContent, 0o600);
           } else {
-            fs.writeFileSync(envPath, `CODEATLAS_API_KEY=${key}\n`, { mode: 0o600 });
+            writeFileSyncNoFollow(envPath, `CODEATLAS_API_KEY=${key}\n`, 0o600);
           }
         }
       } catch (err: any) {

--- a/src/tests/utils/pathUtils.test.ts
+++ b/src/tests/utils/pathUtils.test.ts
@@ -1,0 +1,48 @@
+import { writeFileSyncNoFollow, getHomePath } from "../../utils/pathUtils.js";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+import { describe, it, before, after } from "node:test";
+import * as assert from "node:assert";
+
+describe("pathUtils", () => {
+  describe("writeFileSyncNoFollow", () => {
+    const tempDir = path.join(os.tmpdir(), "codeatlas-test-pathutils-" + Math.random().toString(36).slice(2));
+
+    before(() => {
+      fs.mkdirSync(tempDir, { recursive: true });
+    });
+
+    after(() => {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    });
+
+    it("should write a new file successfully", () => {
+      const filePath = path.join(tempDir, "new-file.txt");
+      writeFileSyncNoFollow(filePath, "test content");
+      assert.strictEqual(fs.readFileSync(filePath, "utf-8"), "test content");
+    });
+
+    it("should truncate and overwrite an existing file", () => {
+      const filePath = path.join(tempDir, "existing-file.txt");
+      fs.writeFileSync(filePath, "old content");
+      writeFileSyncNoFollow(filePath, "new content");
+      assert.strictEqual(fs.readFileSync(filePath, "utf-8"), "new content");
+    });
+
+    it("should throw an error when attempting to write to a symlink", () => {
+      const realFile = path.join(tempDir, "real-file.txt");
+      fs.writeFileSync(realFile, "real content");
+
+      const symlinkPath = path.join(tempDir, "symlink-file.txt");
+      fs.symlinkSync(realFile, symlinkPath);
+
+      assert.throws(() => {
+        writeFileSyncNoFollow(symlinkPath, "malicious content");
+      }, /ELOOP|EBADF/);
+
+      // Verify real file wasn't overwritten
+      assert.strictEqual(fs.readFileSync(realFile, "utf-8"), "real content");
+    });
+  });
+});

--- a/src/utils/pathUtils.ts
+++ b/src/utils/pathUtils.ts
@@ -32,6 +32,10 @@ export function getZedSettingsPath(): string {
   return path.join(getZedConfigDir(), "settings.json");
 }
 
+/**
+ * Writes content to a file securely without following symlinks.
+ * Mitigates Time-of-Check to Time-of-Use (TOCTOU) symlink vulnerabilities.
+ */
 export function writeFileSyncNoFollow(filePath: string, content: string, mode: number = 0o600): void {
   const fd = fs.openSync(
     filePath,


### PR DESCRIPTION
🎯 **What:** Fixed a path traversal vulnerability in `src/presentation/mcpServer.ts` within the `setup_second_brain` tool handler when saving the `CODEATLAS_API_KEY`.
⚠️ **Risk:** An attacker could potentially write the `.env` file to an arbitrary location if they have control over the `homeDir` or symlinks involved, which could overwrite critical system files or lead to credential exposure.
🛡️ **Solution:** Used `fs.realpathSync()` to verify the final resolved directory path is exactly the intended `.codeatlas` folder inside the `homeDir`. We also mitigated a potential Time-of-Check to Time-of-Use (TOCTOU) vulnerability by utilizing `writeFileSyncNoFollow` to write the `.env` file, ensuring symlinks are not followed during file writes.

---
*PR created automatically by Jules for task [14668104525929818504](https://jules.google.com/task/14668104525929818504) started by @giauphan*